### PR TITLE
Update build-a-docker-image.md

### DIFF
--- a/ci-cd/github-actions/build-a-docker-image.md
+++ b/ci-cd/github-actions/build-a-docker-image.md
@@ -24,6 +24,8 @@ To use it you will need to change:
 * `SERVICE_NAME` env var
 * `TENANT_NAME` env var
 
+{% hint style="info" %} Note: The `TENANT_NAME` may need to be lowercase even though the UI shows it in uppercase. {% endhint %}
+
 ```yaml
 name: Build and Deploy
 on:
@@ -49,7 +51,7 @@ jobs:
       - name: Get AWS credentials
         uses: duplocloud/ghactions-aws-jit@master
         with:
-          tenant: default
+          tenant: ${{ env.TENANT_NAME }}
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1


### PR DESCRIPTION
When setting the tenant name to `DEV01` the workflow was failing. Changing it to `dev01` fixed it. The Duplo UI shows the tenant in all uppercase.