### PR TITLE
update_section: AWS User Guide > Terraform support > DuploCloud Terraform Provider

### DIFF
--- a/aws-user-guide/terraform-support/duplocloud-terraform-provider.md
+++ b/aws-user-guide/terraform-support/duplocloud-terraform-provider.md
@@ -1,7 +1,17 @@
 # DuploCloud Terraform Provider
 
-The DuploCloud provider provides resources to interact with the DuploCloud API.
-
-Detailed documentation can be obtained from:
+The DuploCloud provider offers resources for interacting with the DuploCloud API, facilitating the management of cloud resources through Terraform. For comprehensive documentation, visit:
 
 [https://registry.terraform.io/providers/duplocloud/duplocloud/latest/docs](https://registry.terraform.io/providers/duplocloud/duplocloud/latest/docs)
+
+## Retrieving Tenant Security Group ID
+
+When working with DuploCloud and Terraform, you may need to retrieve the tenant security group ID. This can be accomplished by leveraging the AWS security group data source in Terraform, using the security group's name which adheres to the pattern `duploservices-${tenant_name}`. Here's how you can fetch the security group ID:
+
+```terraform
+data "aws_security_group" "selected" {
+  name = "duploservices-${tenant_name}"
+}
+```
+
+Once the data source is defined, the security group ID can be accessed with `data.aws_security_group.selected.id`. This approach utilizes the AWS provider's capabilities in Terraform, combined with the predictable naming convention of DuploCloud security groups, to efficiently retrieve the necessary information without direct support from a specific DuploCloud Terraform Provider data source.


### PR DESCRIPTION
ClickUp Task URL: https://app.clickup.com/t/86a2zedw1
The QA-format documentation snippet provides specific, technical guidance on retrieving a tenant security group ID using Terraform within the context of AWS security groups. Given the existing structure of the documentation, particularly under the 'AWS User Guide' section which includes detailed instructions on various AWS services and Terraform support, this snippet enriches the 'Terraform support' subsection. It offers practical, actionable code and explanation that would update and enhance the 'DuploCloud Terraform Provider' or potentially the 'Using Generated Code' sections, making it more comprehensive for users looking to integrate Terraform with DuploCloud for AWS services. This action supports the goal of keeping the documentation thorough and up-to-date with specific use cases and examples, improving the utility and user experience for developers working with DuploCloud and Terraform.