### PR TITLE
update_section: AWS User Guide > Terraform support > DuploCloud Terraform Provider

### DIFF
--- a/aws-user-guide/terraform-support/duplocloud-terraform-provider.md
+++ b/aws-user-guide/terraform-support/duplocloud-terraform-provider.md
@@ -1,7 +1,7 @@
 # DuploCloud Terraform Provider
 
-The DuploCloud provider provides resources to interact with the DuploCloud API.
+The DuploCloud provider offers resources for seamless interaction with the DuploCloud API, facilitating the management and automation of cloud infrastructure. For users transitioning from AWS CloudFormation, the DuploCloud onboarding team assists in migrating to a DuploCloud-based infrastructure setup. This transition involves replacing existing CloudFormation Infrastructure as Code (IaC) with configurations managed through the DuploCloud UI or automated via DuploCloud Terraform using the DuploCloud Terraform Provider. Post-onboarding, customers can fully leverage DuploCloud's capabilities without the need to write or maintain CloudFormation templates, streamlining their cloud management processes.
 
-Detailed documentation can be obtained from:
+For comprehensive documentation and further details, visit:
 
 [https://registry.terraform.io/providers/duplocloud/duplocloud/latest/docs](https://registry.terraform.io/providers/duplocloud/duplocloud/latest/docs)


### PR DESCRIPTION
ClickUp Task URL: https://app.clickup.com/t/86a3ae7xm
The provided QA-format documentation snippet details the process of transitioning from AWS CloudFormation to DuploCloud's UI configuration or Terraform for infrastructure as code (IaC), which is a critical aspect of the onboarding process for new customers. Given the existing structure of the documentation, this information would enrich the 'Getting Started with DuploCloud' section under 'Getting Started'. This section already aims to guide new users through initial setup and configuration, making it the ideal place to include detailed information on how DuploCloud assists in migrating from CloudFormation to DuploCloud's preferred IaC methods. Updating this section ensures that new users have access to comprehensive onboarding information in a centralized location, improving the user experience by providing clear guidance on transitioning their existing IaC setups to DuploCloud.