### PR TITLE
update_section: Kubernetes User Guide > HPA

### DIFF
--- a/kubernetes/hpa.md
+++ b/kubernetes/hpa.md
@@ -1,7 +1,23 @@
 ---
-description: Support Kubernetes Horizontal Pod Autoscaler in the DuploCloud Portal
+description: Support Kubernetes Horizontal Pod Autoscaler in the DuploCloud Portal, including managing and troubleshooting services with HPA configured.
 ---
 
 # HPA
 
 See the [Autoscaling in Kubernetes](../aws-user-guide/use-cases/hosts-vms/auto-scaling/kubernetes-scaling-options.md) topic in the AWS DuploCloud documentation.
+
+## Managing Services with HPA
+
+When working with Kubernetes services configured with Horizontal Pod Autoscaler (HPA), it's important to understand how to effectively manage and troubleshoot these services. 
+
+### Stopping a Service with HPA
+
+To stop a service that is stuck in the Running state due to HPA, directly deleting pods will not suffice as new ones will be created to maintain the set number of replicas. Instead, you should remove the HPA configuration and adopt a static replication strategy by setting the replica count to 0. This ensures the service is effectively stopped without attempting to set `minReplicas` to 0, which is an invalid configuration for HPA.
+
+### Troubleshooting
+
+If issues arise while stopping a service with HPA configured, avoid setting `minReplicas` to 0 and ensure the HPA configuration is removed in favor of a static replication strategy. For further troubleshooting, consult the Faults menu under the DevOps section in the DuploCloud UI, where all errors are logged, facilitating efficient diagnosis and resolution.
+
+### UI Improvements
+
+DuploCloud is planning enhancements to the UI to improve the management of services running with HPA configurations. These improvements include adding validation to prevent setting `minReplicas` to 0, potentially removing the `Stop` option for services with HPA, and clearly documenting the correct procedure for stopping such services. These updates aim to simplify the process and prevent common configuration mistakes, ensuring a smoother experience in managing Kubernetes services with HPA.

--- a/kubernetes/hpa.md
+++ b/kubernetes/hpa.md
@@ -12,7 +12,7 @@ When working with Kubernetes services configured with Horizontal Pod Autoscaler 
 
 ### Stopping a Service with HPA
 
-To stop a service that is stuck in the Running state due to HPA, directly deleting pods will not suffice as new ones will be created to maintain the set number of replicas. Instead, you should remove the HPA configuration and adopt a static replication strategy by setting the replica count to 0. This ensures the service is effectively stopped without attempting to set `minReplicas` to 0, which is an invalid configuration for HPA.
+To stop a service that is stuck in the Running state due to HPA, you cannot directly deleting pods, as new ones are created to maintain the set number of replicas. Instead, remove the HPA configuration and adopt a static replication strategy by setting the replica count to 0. This ensures the service is effectively stopped without attempting to set `minReplicas` to 0, which is an invalid configuration for HPA.
 
 ### Troubleshooting
 


### PR DESCRIPTION
ClickUp Task URL: https://app.clickup.com/t/86a38mmnd
The QA-format documentation snippet provides specific guidance on stopping a Kubernetes service running with HPA configured, which is a detailed operational procedure relevant to users managing Kubernetes services. Given the existing documentation structure, there is a dedicated section under 'Kubernetes User Guide' that covers various aspects of Kubernetes management, including HPA. Updating this section with the provided snippet will enrich the existing content by offering practical, problem-solving guidance directly related to HPA management. This action supports the documentation's goal of being a comprehensive resource for users, ensuring they have access to up-to-date and actionable information for managing Kubernetes services within the DuploCloud platform.