### PR TITLE
update_section: Kubernetes User Guide > Kubectl setup > KubeCtl Token

### DIFF
--- a/kubernetes/kubectl-setup/kubectl-token.md
+++ b/kubernetes/kubectl-setup/kubectl-token.md
@@ -1,12 +1,12 @@
 ---
-description: Set up KubeCtl within the DuploCloud Portal by downloading the token
+description: Set up KubeCtl within the DuploCloud Portal by downloading the token and configuring Mirantis Lens for DuploCloud authentication.
 ---
 
-# KubeCtl Token
+# KubeCtl Token and Mirantis Lens Configuration
 
 ## Downloading the KubeCtl token
 
-DuploCloud provides a way to connect directly to the Cluster namespace using the `kubectl` token.&#x20;
+DuploCloud provides a way to connect directly to the Cluster namespace using the `kubectl` token. This facilitates direct interaction with your Kubernetes cluster through a command-line interface.
 
 {% hint style="warning" %}
 If you attempt to start a **KubeCtl Shell** instance and receive a **503** in your web browser, ensure that the **duplo-shell** service in the **Default** Tenant is running and that the Hosts which support it are running, as well.
@@ -18,7 +18,22 @@ If you attempt to start a **KubeCtl Shell** instance and receive a **503** in yo
 <figure><img src="../../.gitbook/assets/Screenshot (349).png" alt=""><figcaption><p>The <strong>Kubernetes Services</strong> page with <strong>KubeCtl Token</strong> button</p></figcaption></figure>
 
 <div align="left">
-
 <img src="../../.gitbook/assets/image (1) (3).png" alt="Token window with kubectl commands for creating token">
-
 </div>
+
+## Configuring Mirantis Lens for DuploCloud Authentication
+
+To enhance your Kubernetes management experience, you can integrate Mirantis Lens with DuploCloud by following these steps:
+
+1. **Install DuploCloud Client:** Ensure the `duploctl` command-line tool is installed. If not, use `pip install duplocloud-client` to install it.
+2. **Install Lens Client:** Download and install the Lens Kubernetes IDE client from its official website.
+3. **Generate Kubeconfig File:** With `duploctl`, generate a kubeconfig file for Lens connection:
+   ```
+   duploctl jit update_kubeconfig --plan nonprod01 --tenant $DUPLO_TENANT --host https://$DUPLO_HOST --token $DUPLO_TOKEN
+   ```
+4. **Add Kubeconfig to Lens:** In Lens, navigate to "Catalog" and use the `+` button to add the kubeconfig file, configuring Lens to connect to your Kubernetes cluster.
+5. **Connect to the Cluster:** Lens will prompt for login through a browser window. For private EKS clusters, ensure VPN connectivity for authentication.
+
+**Note:** After your session, disconnect from the cluster to avoid repeated browser tab openings during re-authentication attempts.
+
+Integrating Mirantis Lens with DuploCloud enhances your Kubernetes cluster management by providing a powerful graphical interface alongside the direct command-line access provided by the `kubectl` token.


### PR DESCRIPTION
ClickUp Task URL: https://app.clickup.com/t/86a3b962q
The provided QA-format documentation snippet offers detailed steps on configuring Mirantis Lens for DuploCloud authentication, which is a specific technical procedure related to Kubernetes setup and usage. Given the existing documentation structure, this content enriches the 'Kubernetes User Guide' section, particularly under 'Kubectl setup' or a similar subsection that deals with Kubernetes configurations and integrations. Updating an existing section ensures that users looking for Kubernetes-related setup and configuration information will find comprehensive guidance in one place, enhancing the utility and coherence of the documentation. This approach avoids fragmenting related information across multiple sections or formats, thereby improving the user experience by maintaining a structured and predictable documentation layout.