### PR TITLE
update_section: AWS User Guide > AWS Services > Databases > RDS database

### DIFF
--- a/aws-user-guide/aws-services/database/rds-database/README.md
+++ b/aws-user-guide/aws-services/database/rds-database/README.md
@@ -30,7 +30,9 @@ When upgrading RDS versions, use AWS Console and see your Cloud Provider for com
 1. In the DuploCloud Portal, navigate to **Cloud Services** -> **Database**.
 2. Click **Add**. The **Create a RDS** page displays.
 3. Fill out the form based on your requirements, and **Enable Logging**, if needed.
-4. Optionally, in the **Backup Retention Period in Days** field, enter a number of days to retain automated backups between one (**1**) and thirty-five (**35**). If a value is not entered, the Backup Retention Period value configured in Systems Settings will be applied.&#x20;
+4. Optionally, in the **Backup Retention Period in Days** field, enter a number of days to retain automated backups between one (**1**) and thirty-five (**35**). If a value is not entered, the Backup Retention Period value configured in Systems Settings will be applied.
+
+To create a publicly available RDS database, ensure the DB Subnet Group selected consists only of public subnets from your VPC. This configuration is crucial for making the database accessible publicly.
 
 <figure><img src="../../../../.gitbook/assets/screenshot-nimbusweb.me-2024.02.19-17_16_19.png" alt=""><figcaption><p><strong>Create a RDS</strong> window</p></figcaption></figure>
 
@@ -41,6 +43,8 @@ You can create Aurora Serverless V2 Databases by selecting **Aurora-MySql-Server
 ## Connecting to the database <a href="#id-1-toc-title" id="id-1-toc-title"></a>
 
 Once the database is created, select it and use the **Instances** tab to view the endpoint and credentials. Use the **Endpoints** and credentials to connect to the database from your application running in an EC2 instance. The database is only accessible from inside the EC2 instance in the current Tenant, including the containers running within.
+
+For databases intended to be publicly available, ensure proper security measures are in place to protect your data, considering the broader accessibility.
 
 <figure><img src="../../../../.gitbook/assets/screenshot-nimbusweb.me-2024.02.19-17_18_36.png" alt=""><figcaption><p><strong>RDS Instances</strong> tab</p></figcaption></figure>
 


### PR DESCRIPTION
ClickUp Task URL: https://app.clickup.com/t/86a3jea7c
The provided QA-format documentation snippet offers detailed steps on creating a publicly available RDS database, which directly relates to the 'AWS Services' section under 'Databases' in the current documentation. Specifically, it can enrich the 'RDS database' subsection by providing a practical, step-by-step guide that complements the existing content on RDS databases, including setup, authentication, backup, and monitoring. Updating this section with the new snippet will ensure that the documentation remains comprehensive and up-to-date, offering users a clear and concise resource for creating publicly available RDS databases. This action supports the goal of maintaining a centralized, authoritative source of information that meets the users' needs for specific, actionable guidance on utilizing AWS services within the DuploCloud platform.