### PR TITLE
update_section: GCP User Guide > Container deployments > Key DuploCloud concepts

### DIFF
--- a/overview-1/container-deployments/concepts.md
+++ b/overview-1/container-deployments/concepts.md
@@ -12,18 +12,22 @@ These are virtual machines. In GCP deployments, they are also called Worker node
 
 ## Service
 
-Service is a DuploCloud term. DuploCloud Services are not Kubernetes Services. Services are microservices that are defined by a Name, DockerImage, and a number of replicas in addition to many other optional parameters. Behind the scenes, a DuploCloud Service maps 1:1 either to a Kubernetes deployment set or to a StatefulSet depending on whether the microservice has stateful volumes or not. There are many optional configurations associated with a DuploCloud Service that represent various ways Docker containers can be run. A few of these are:
+Service is a DuploCloud term. DuploCloud Services are not Kubernetes Services. Services are microservices that are defined by a Name, DockerImage, and a number of replicas in addition to many other optional parameters. Behind the scenes, a DuploCloud Service maps 1:1 either to a Kubernetes deployment set or to a StatefulSet depending on whether the microservice has stateful volumes or not. 
 
-* Environment variables&#x20;
-* Host Network Mode&#x20;
-* Volume mounts&#x20;
-* Entrypoint or command overrides&#x20;
-* Resource caps&#x20;
+When deploying services, especially in a staging environment, it's crucial to ensure that containers have the necessary permissions for read/write operations. This may involve configuring a security context within the service's configuration to address local write failures, a common issue when containers are restricted compared to their local development environment. This adjustment ensures that the container can write to temporary file directories on the server, facilitating smooth deployment and operation.
+
+Services have many optional configurations representing various ways Docker containers can be run, including:
+
+* Environment variables
+* Host Network Mode
+* Volume mounts
+* Entrypoint or command overrides
+* Resource caps
 * Health Checks
 
 ## Allocation Tags
 
-If a service needs to be pinned to run only a specific set of hosts, set an Allocation Tag on the Hosts as well as on the Service. The Allocation Tag is a case-insensitive substring match. For example, an Allocation Tag specified on a service is usually a substring of the tag specified on the host. A Host may be tagged as **HighCpu;HighMem** and the Service (if tagged **highcpu**) can be allocated on the Host. However, if the service is tagged **highcpu;gpu** then it won't be allocated and needs a host that has been tagged **highcpu;gpu**_._ If a Service does not have any tag set, it can be placed on any host.
+If a service needs to be pinned to run only a specific set of hosts, set an Allocation Tag on the Hosts as well as on the Service. The Allocation Tag is a case-insensitive substring match. For example, an Allocation Tag specified on a service is usually a substring of the tag specified on the host. A Host may be tagged as **HighCpu;HighMem** and the Service (if tagged **highcpu**) can be allocated on the Host. However, if the service is tagged **highcpu;gpu** then it won't be allocated and needs a host that has been tagged **highcpu;gpu**. If a Service does not have any tag set, it can be placed on any host.
 
 {% hint style="warning" %}
 If the Host is tagged with a specific value and you have Services with the same tag, the host is available for any Service which has no tags. If you want the exclusive assignment of a Host to a set of Services, ensure that every Service in the Tenant is tagged with some value.
@@ -31,5 +35,7 @@ If the Host is tagged with a specific value and you have Services with the same 
 
 In the case of Kubernetes deployments, the concept of Allocation Tags maps to labels on nodes, and on node selectors on the deployment set or StatefulSet.
 
-* **Host Networking:** By default, Docker containers have their own network addresses. you may want these containers to use the same network interface as the VM. This is called Host Network Mode.
-* **Load Balancer:** If a service must be accessed by other services, it needs to be exposed using internal and external load balancers.&#x20;
+* **Host Networking:** By default, Docker containers have their own network addresses. If you want these containers to use the same network interface as the VM, this is achieved through Host Network Mode.
+* **Load Balancer:** If a service must be accessed by other services, it needs to be exposed using internal and external load balancers.
+
+This comprehensive approach ensures that services are deployed efficiently and securely, with appropriate configurations for networking, permissions, and resource allocation, facilitating a smooth operation across different environments.


### PR DESCRIPTION
ClickUp Task URL: https://app.clickup.com/t/86a428fm3
The QA-format documentation snippet provides detailed steps on resolving local write failures in containerized environments, which is a technical issue related to container deployments. Given the current documentation structure, this content enriches the 'Container Orchestrators' section, specifically under troubleshooting or operational guidance for container deployments. Updating this section with the snippet ensures that users facing similar issues can find solutions within the context of existing container deployment documentation, enhancing the utility and comprehensiveness of the guides without fragmenting related information across different documentation formats or sections.