### PR TITLE
ASK-764--add_faq

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -93,7 +93,8 @@ The following is a list of automation constructs managed by DuploCloud and a sum
 1. Cloud Provider Configuration (Terraform): This involves various cloud services, IAM roles, Security groups, VPC, etc. DuploCloud can export your latest cloud configuration into native Terraform code and state files. Once exported, you maintain the configuration.
 2. Kubernetes: All applications and configurations deployed in K8s are available as deployments, StatefulSets, DaemonSet, K8s Secrets, ConfigMaps, etc. One can run `kubectl` commands to export configurations as YAML files and continue to maintain them in the future.
 3. Compliance monitoring: DuploCloud uses a third-party SIEM solution called [Wazuh](https://www.wazuh.com). Wazuh is an open-source software platform running in an independent VM in your cloud account, and you have full permission to retain it "as-is." However, in the future, you need to integrate any new systems that need compliance monitoring into the SIEM.
-4. Diagnostics tools: These include Prometheus, Grafana, and Elasticsearch. They are all open source and run in your cloud account, so you can continue to manage them directly.
+4. Diagnostics tools: These include Prometheus, Grafana, and Elasticsearch. They are
+ all open source and run in your cloud account, so you can continue to manage them directly.
 
 {% hint style="info" %}
 If DuploCloud is down, it's similar to having an unavailable DevOps engineer. If you need to opt out of DuploCloud, you are replacing your DevOps management. DuploCloud is neither a PaaS nor a hosted solution that hosts your workloads.
@@ -135,7 +136,10 @@ DuploCloud provides flexibility when a feature not supported by DuploCloud can b
 
 Yes. DuploCloud's Web UI is a no-code interface for DevOps. You do not need to know IaC or have cloud expertise to operate it. However, you should read the product documentation to understand the basic constructs in DuploCloud. This approach significantly reduces the risk of errors associated with manual configurations or "Click Ops," ensuring that your infrastructure follows best practices with just a few clicks.
 
-### Isn't No Code Click Ops?
+### Configuring DuploCloud CLI on Windows Subsystem for Linux (WSL)
+
+For users leveraging WSL, configuring DuploCloud CLI requires specific steps to ensure smooth operation, especially for tasks involving interactive browser sessions or AWS CLI usage. Users may need to install utilities like `xclip`, `xdg-utils`, and `jq` to facilitate these operations. Additionally, setting up aliases in the `.bashrc` file for `start` and `open` commands to point to `xdg-open`, and defining the `BROWSER` environment variable to the path of a browser in `/usr/local/bin` are crucial steps. Creating a symlink in `/usr/local/bin` to the browser executable located in the Windows file system allows DuploCloud CLI to utilize the Windows browser for authentication and other browser-required operations. While optional, adding aliases for `pbcopy` and `pbpaste` can enhance script compatibility, particularly for users accustomed to macOS environments. These configurations enable effective use of DuploCloud CLI within WSL, bridging the gap between Windows and Linux environments for cloud management tasks.
+ Isn't No Code Click Ops?
 
 "Click Ops" is when engineers manually create infrastructure resources in the cloud and other UIs. It's often considered bad practice because there are so many components and configurations that it's easy to make mistakes. DuploCloud manages infrastructure resources for you, ensuring the underlying compute instances, firewall rules, IAM policies, and other components are configured following good practices. You only need a few clicks and don't need to know DevSecOps because DuploCloud knows it for you.
 


### PR DESCRIPTION
ClickUp Task URL: https://app.clickup.com/t/86a3y7rew
The QA-format documentation snippet provides a straightforward solution to a common problem that users might encounter when configuring DuploCloud CLI on Windows Subsystem for Linux (WSL), specifically regarding browser sessions and AWS CLI usage. Adding this snippet to the FAQs section would directly address user queries related to this setup, making it easier for users to find solutions to their problems without having to navigate through multiple sections of the documentation. This approach enhances user experience by consolidating practical, question-oriented guidance in a single, easily accessible location.