### PR TITLE
update_section: AWS User Guide > AWS Services > Load Balancers > Step 7: Enable additional options for the Load Balancer (optional)

### DIFF
--- a/overview/quick-start/quick-start-eks-services/step-7-secure-the-load-balancer.md
+++ b/overview/quick-start/quick-start-eks-services/step-7-secure-the-load-balancer.md
@@ -16,7 +16,7 @@ Otherwise, to skip this step, proceed to the [next page in this tutorial](step-8
 
 In this tutorial step, for the Application Load Balancer (ALB) you created in [Step 6](../quick-start-duplocloud-docker-services/step-6-create-loadbalancer.md), you will:&#x20;
 
-* Enable access logging to monitor [HTTP message](https://en.wikipedia.org/wiki/HTTP\_message\_body) details.
+* Enable access logging to monitor [HTTP message](https://en.wikipedia.org/wiki/HTTP\_message\_body) details and record incoming traffic data. Access logs are crucial for analyzing traffic patterns and identifying potential threats, but they are not enabled by default. You must manually activate them in the load balancer's configuration settings.
 * Protect against requests that contain [invalid headers](https://en.wikipedia.org/wiki/List\_of\_HTTP\_header\_fields).
 
 _Estimated time to complete Step 7: 5 minutes._
@@ -70,3 +70,4 @@ Verify that the **Other Settings** card contains the selections you made above f
 
 <figure><img src="../../../.gitbook/assets/ihatethis.png" alt=""><figcaption><p><strong>Load Balancers</strong> tab on the <strong>Services</strong> page with <strong>Other Settings</strong> card, including set options </p></figcaption></figure>
 
+By enabling access logs, you've taken a significant step towards enhancing the security and monitoring capabilities of your load balancer. This feature is instrumental in providing insights into the traffic accessing your application, allowing for a more robust security posture.


### PR DESCRIPTION
ClickUp Task URL: https://app.clickup.com/t/86a42xu2p
The provided QA-format documentation snippet about enabling access logs for an ingress application load balancer directly relates to the configuration and management of load balancers, a topic already covered under the 'Load Balancers' section in the AWS User Guide portion of the documentation. Specifically, it can enrich the subsections dealing with EKS, ECS, and native Docker load balancers by providing additional, valuable information on how to enable access logs, which is a crucial aspect of monitoring and diagnostics for these services. Updating this section with the new snippet will ensure that the documentation remains comprehensive and up-to-date, offering users a centralized resource for all load balancer-related configurations and best practices.