### PR TITLE
update_section: AWS User Guide > AWS Services > S3 Bucket

### DIFF
--- a/overview/aws-services/s3-bucket.md
+++ b/overview/aws-services/s3-bucket.md
@@ -7,49 +7,47 @@ description: Create an S3 bucket for AWS storage
 Amazon Simple Storage Service (Amazon S3) is an object-storage service offering scalability, data availability, security, and performance. You can store and protect any data for data lakes, cloud-native applications, and mobile apps. Read more about S3 and its capabilities [here](https://aws.amazon.com/s3/).
 
 {% hint style="info" %}
-To configure an S3 bucket for auditing, see the [Auditing ](../use-cases/auditing.md)topic.
+To configure an S3 bucket for auditing, see the [Auditing](../use-cases/auditing.md) topic.
 {% endhint %}
 
 ## Creating an S3 bucket
 
 {% hint style="info" %}
-When creating an S3 bucket using the `duplocloud_s3_bucket` resource in Terraform, a unique identifier is appended to the bucket name to ensure global uniqueness, as AWS requires. This identifier is the AWS account ID and a prefix with the tenant name (`duploservices-<tenant_name>-`) is also added. This naming convention allows for creating buckets with the same name across multiple tenants while maintaining global uniqueness.
+When creating an S3 bucket using the `duplocloud_s3_bucket` resource in Terraform, a unique identifier is appended to the bucket name to ensure global uniqueness, as AWS requires. This identifier is the AWS account ID, and a prefix with the tenant name (`duploservices-<tenant_name>-`) is also added. This naming convention allows for creating buckets with the same name across multiple tenants while maintaining global uniqueness. DuploCloud automatically adds a prefix and a suffix to bucket names to minimize naming conflicts in the global S3 namespace.
 {% endhint %}
 
 1. In the DuploCloud Portal, navigate to **Cloud Services** -> **Storage**.
 2. Click the **S3** tab.
-3. Click **Add**. The **Create an S3** **Bucket** pane displays.
+3. Click **Add**. The **Create an S3 Bucket** pane displays.
 4. In the **Name** field, enter a name for the S3 bucket.
 5. In the **Region** list box, select the region. You can choose Region Tenant, **Default Region**, or **Global Region** and specify **Other Region** to enter a custom region you have defined.
 
 <figure><img src="../../.gitbook/assets/screenshot-nimbusweb.me-2024.02.19-14_38_40.png" alt=""><figcaption><p>The <strong>Create an S3 Bucket</strong> pane</p></figcaption></figure>
 
-6. Optionally, select **Enable Bucket Versioning** or **Object Lock.** These settings are disabled by default unless you Enable Bucket Versioning Tenant-wide in **Tenant** **Settings**. For more information about S3 bucket versioning, see the [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/versioning-workflows.html).&#x20;
+6. Optionally, select **Enable Bucket Versioning** or **Object Lock.** These settings are disabled by default unless you Enable Bucket Versioning Tenant-wide in **Tenant Settings**. For more information about S3 bucket versioning, see the [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/versioning-workflows.html). It's important to note that while DuploCloud supports enabling versioning, managing versions and the deletion of versioned objects may require manual steps through the AWS console or CLI, especially since DuploCloud's current Terraform operations perform only basic delete operations.
 7. Click **Create**. An S3 bucket is created.
 
 {% hint style="info" %}
-**Enable Bucket Versioning** must be selected to use **Object Lock**.&#x20;
+**Enable Bucket Versioning** must be selected to use **Object Lock**. For environments not subject to compliance requirements, consider disabling versioning on buckets to simplify the creation and destruction of development tenants. However, disabling versioning does not delete existing versions.
 {% endhint %}
 
 ### Enabling bucket versioning for S3 buckets at the Tenant level
 
-You can configure the [Tenant ](../use-cases/tenant-environment/#2-toc-title)to enable bucket versioning by default.&#x20;
+You can configure the [Tenant](../use-cases/tenant-environment/#2-toc-title) to enable bucket versioning by default.
 
 1. In the DuploCloud Portal, navigate to **Administrator** -> **Tenants**.
 2. Click on the **Tenant** name in the list.
 3. In the **Settings** tab, click **Add**. The **Add Tenant Feature** pane displays.
 4. Click **Add**. The **Create an S3 Bucket** pane displays.
 5. From the **Select Tenant Feature** list box, select **Default: Enable bucket versioning for new S3 buckets**.
-6.  Select **Enable.**\
-
+6. Select **Enable**.
 
     <div align="left">
 
     <figure><img src="../../.gitbook/assets/add tenant feature.png" alt=""><figcaption><p>The <strong>Add Tenant Feature</strong> pane filled to enable bucket versioning for this Tenant.<br></p></figcaption></figure>
 
     </div>
-7.  Click **Add**. Bucket versioning will be enabled by default on the **Create an S3 Bucket** pane when [creating a new S3 bucket](s3-bucket.md#creating-an-s3-bucket).\
-
+7. Click **Add**. Bucket versioning will be enabled by default on the **Create an S3 Bucket** pane when [creating a new S3 bucket](s3-bucket.md#creating-an-s3-bucket).
 
     <div align="left">
 
@@ -58,18 +56,17 @@ You can configure the [Tenant ](../use-cases/tenant-environment/#2-toc-title)to 
     </div>
 
 {% hint style="info" %}
-With this setting configured, all new S3 buckets in the Tenant will automatically enable bucket versioning.&#x20;
+With this setting configured, all new S3 buckets in the Tenant will automatically enable bucket versioning.
 {% endhint %}
 
 ## Setting S3 bucket permissions and policies
 
 {% hint style="warning" %}
-It is advisable to manage SES-specific buckets not managed by DuploCloud independently. Duplo's default bucket policy enforces encryption, which complements SES's automatic encryption for incoming emails. \
-\
-You should manage your bucket policies if DuploCloud overwrites the custom policy to update an S3 Bucket defined in DuploCloud for SES. \
+It is advisable to manage SES-specific buckets not managed by DuploCloud independently. Duplo's default bucket policy enforces encryption, which complements SES's automatic encryption for incoming emails.
 
+You should manage your bucket policies if DuploCloud overwrites the custom policy to update an S3 Bucket defined in DuploCloud for SES.
 
-Manage your S3 Bucket by setting `managed_policies ignore` in the DuploCloud Terraform provider, select **Ignore bucket policies** in the DuploCloud Portal when creating or editing your S3 Bucket.&#x20;
+Manage your S3 Bucket by setting `managed_policies ignore` in the DuploCloud Terraform provider, select **Ignore bucket policies** in the DuploCloud Portal when creating or editing your S3 Bucket.
 {% endhint %}
 
 You can set specific AWS S3 bucket [permissions and policies](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingBucket.html#about-access-permissions-create-bucket) using the DuploCloud Portal. Permissions for virtual machines, Lambda functions, and containers are provisioned automatically through Instance profiles, so no access key is required in your application code. However, when coding your application, be aware of these guidelines:
@@ -84,11 +81,9 @@ Set S3 Bucket permissions in the DuploCloud Portal:
 3. From the **Name** column, select the bucket for which you want to set permissions. The **S3 Bucket** page for your bucket displays.
 4. In the **Settings** tab, click **Edit**. The **Edit a S3 Bucket** pane displays.
 5. From the **KMS** list box, select the key management system scope (**AWS Default KMS Key**, **Tenant KMS Key**, etc.).
-6. Select permissions: **Allow Public Access**, **Enable Access Logs**, or **Enable Versioning**.&#x20;
+6. Select permissions: **Allow Public Access**, **Enable Access Logs**, or **Enable Versioning**.
 7. Select an available **Bucket Policy: Require SSL/HTTPS** or **Allow Public Read**. To select the **Allow Public Read** policy, you must select the **Allow Public Access** permission. To ignore all bucket policies for the bucket, choose Ignore Bucket **Policies**.
 8. Click **Save**. In the **Details** tab, your changed permissions are displayed.
-
-Use this table to map the permission and policies options above with the YAML key/value pair.
 
 {% hint style="info" %}
 From the **S3 Bucket** page, you can set bucket permissions directly in the AWS Console by clicking the **>\_Console** icon. You have permission to configure the bucket within the AWS Console session, but no access or security-level permissions are available.
@@ -99,7 +94,7 @@ From the **S3 Bucket** page, you can set bucket permissions directly in the AWS 
 DuploCloud provides the capability to specify a custom prefix for S3 buckets, enhancing naming conventions and organizational strategies. Before adding custom prefixes, ensure the `ENABLEAWSRESOURCEMGMTUSINGTAGS` property is set to `True` in DuploCloud by contacting the DuploCloud Support Team using your Slack channel. This setting allows for a more tailored bucket naming approach that can reflect your organization's naming conventions or project identifiers.
 
 {% hint style="warning" %}
-Avoid specifying system-reserved prefixes such as`duploservices`.
+Avoid specifying system-reserved prefixes such as `duploservices`.
 {% endhint %}
 
 1. In the DuploCloud Portal, navigate to **Administrator** -> **System Settings**.
@@ -115,3 +110,7 @@ Avoid specifying system-reserved prefixes such as`duploservices`.
 <figure><img src="../../.gitbook/assets/AWS_GCP_Bucket_prefix.png" alt=""><figcaption><p><strong>Add Config</strong> pane for <strong>Key Prefix all S3 Bucket Name</strong></p></figcaption></figure>
 
 </div>
+
+{% hint style="info" %}
+When attempting to delete S3 buckets, it's crucial to first empty the bucket. DuploCloud is planning to introduce a "force delete data" feature to simplify this process, including version deletions. Until then, manual deletion through the AWS console is a reliable method for smaller buckets. For managing versions, users may need to use the AWS CLI, as DuploCloud's Terraform operations currently only perform basic delete operations.
+{% endhint %}


### PR DESCRIPTION
ClickUp Task URL: https://app.clickup.com/t/86a4qhmyp
The provided QA-format documentation snippet offers detailed insights into handling S3 bucket deletion and versioning within DuploCloud, which is a topic closely related to the existing AWS Services section, specifically under 'S3 Bucket'. Since the snippet enriches the current documentation with specific operational guidance, including manual deletion steps, versioning considerations, and future feature plans, it naturally fits as an update to the existing 'S3 Bucket' section. This approach ensures that users seeking information on S3 bucket management within DuploCloud have access to comprehensive, up-to-date guidance in a single, consolidated section of the documentation. It avoids fragmenting related information across multiple sections or formats, thereby enhancing the user experience by maintaining topic cohesion and navigational ease.