### PR TITLE
update_section: AWS User Guide > AWS Services > Virtual Private Cloud (VPC) Peering

### DIFF
--- a/overview/aws-services/virtual-private-cloud-vpc-peering.md
+++ b/overview/aws-services/virtual-private-cloud-vpc-peering.md
@@ -8,7 +8,7 @@ VPC [peering ](https://en.wikipedia.org/wiki/Peering)is a networking connection 
 
 VPC peering facilitates the transfer of data. For example, if you have more than one AWS account, you can peer the VPCs across those accounts and create a file-sharing network.&#x20;
 
-This procedure describes how to peer two VPCs, using subnet routes, and how to manage the peering connections and routes.
+This procedure describes how to peer two VPCs, using subnet routes, and how to manage the peering connections and routes. For detailed steps on setting up VPC peering in Duplo, refer to the [Duplo documentation](https://docs.duplocloud.com/docs/overview/aws-services/virtual-private-cloud-vpc-peering).
 
 ## Enable and peer VPCs
 


### PR DESCRIPTION
ClickUp Task URL: https://app.clickup.com/t/86a55wmyq
The provided QA-format documentation snippet about setting up VPC peering in Duplo directly relates to an existing topic within the current documentation structure under 'AWS Services' -> 'Virtual Private Cloud (VPC) Peering'. Since the snippet offers a straightforward guide on how to perform VPC peering in Duplo, it enriches the existing section with specific procedural information. Updating this section will ensure that the documentation remains comprehensive and up-to-date, providing users with a clear, step-by-step guide on how to execute VPC peering within the DuploCloud environment. This action supports the goal of maintaining a cohesive and informative documentation resource for users, enhancing their ability to find and utilize information on VPC peering without navigating away to additional sections or external resources.