### PR TITLE
update_section: AWS User Guide > Prerequisites > VPN Setup

### DIFF
--- a/overview/prerequisites/vpn-setup.md
+++ b/overview/prerequisites/vpn-setup.md
@@ -1,16 +1,16 @@
 ---
-description: Accept OpenVPN, provision the VPN, and add VPN users
+description: Accept OpenVPN, provision the VPN, add VPN users, and manage connection limits
 ---
 
 # VPN Setup
 
-DuploCloud integrates with OpenVPN by provisioning VPN users that you add to the DuploCloud Portal. OpenVPN setup is a two-step process.
+DuploCloud integrates with OpenVPN by provisioning VPN users that you add to the DuploCloud Portal. OpenVPN setup is a comprehensive process that includes accepting OpenVPN, provisioning the VPN, adding users, and managing connection limits to accommodate a growing team.
 
 ## Accepting OpenVPN
 
-Accept OpenVPN Free Tier (Bring Your Own License) in the AWS Marketplace:&#x20;
+Accept OpenVPN Free Tier (Bring Your Own License) in the AWS Marketplace:
 
-1. Log into your AWS account. In the console, navigate to: [https://aws.amazon.com/marketplace/pp?sku=f2ew2wrz425a1jagnifd02u5t](https://aws.amazon.com/marketplace/pp?sku=f2ew2wrz425a1jagnifd02u5t).&#x20;
+1. Log into your AWS account. In the console, navigate to: [https://aws.amazon.com/marketplace/pp?sku=f2ew2wrz425a1jagnifd02u5t](https://aws.amazon.com/marketplace/pp?sku=f2ew2wrz425a1jagnifd02u5t).
 2. Accept the agreement. Other than the regular EC2 instance cost, no additional license costs are added.
 
 ## Provisioning the VPN
@@ -19,27 +19,31 @@ Accept OpenVPN Free Tier (Bring Your Own License) in the AWS Marketplace:&#x20;
 2. Select the **VPN** tab.
 3. Click **Provision VPN.**
 
-After the OpenVPN is provisioned, it is ready to use. Behind the scenes, DuploCloud launches a CloudFormation script to provision the OpenVPN.   &#x20;
+After the OpenVPN is provisioned, it is ready to use. DuploCloud automates the setup by launching a CloudFormation script to provision the OpenVPN.
 
 ![The VPN tab on the System Settings page in the DuploCloud Portal](<../../.gitbook/assets/image (244).png>)
 
 {% hint style="info" %}
-You can find the OpenVPN admin password in the CloudFormation stack in your AWS console.
+The OpenVPN admin password can be found in the CloudFormation stack in your AWS console.
 {% endhint %}
+
+## Managing VPN Connection Limits
+
+To support a growing team, you may need to increase the number of VPN connections. This can be achieved by purchasing a larger license from your VPN provider. Once acquired, update the license key in the VPN's web user interface through the DuploCloud team's assistance. Ensure the user count settings in the VPN reflect the new limit and verify team access to manage these changes efficiently.
 
 ## Adding or Deleting a VPN User
 
-For instructions to add or delete a VPN user, see the DuploCloud [User Administration documentation](../../access-control/add-and-delete-vpn-access-for-users.md).
+For instructions to add or delete a VPN user, refer to the DuploCloud [User Administration documentation](../../access-control/add-and-delete-vpn-access-for-users.md).
 
 ## Opening a VPN Port
 
-Users connected to a VPN can SSH or RDP into EC2 instances by default. Users can also connect to internal application Load Balancers and endpoints. However, to connect to other Services, such as databases and ElastiCache, you must open the port to the VPN:&#x20;
+To enable users connected to the VPN to access various services, including databases and ElastiCache, specific ports must be opened:
 
 1. In the DuploCloud Portal, navigate to **Administrator** -> **Tenants**.
 2. Select the Tenant from the **NAME** column.
 3. Click the **Security** tab.
 4. Click **Add**. The **Add Tenant Security** pane displays.
-5. From the **Source Type** list box, select **IP Address**.&#x20;
+5. From the **Source Type** list box, select **IP Address**.
 6. From the **IP CIDR** list box, select your IP CIDR.
 7. Click **Add**.
 
@@ -48,3 +52,5 @@ Users connected to a VPN can SSH or RDP into EC2 instances by default. Users can
 <figure><img src="../../.gitbook/assets/Add_Tenant_Security.png" alt=""><figcaption><p>The <strong>Add Tenant Security</strong> pane</p></figcaption></figure>
 
 </div>
+
+This comprehensive guide ensures your VPN setup is not only up and running but also scalable to meet the needs of your growing team.


### PR DESCRIPTION
ClickUp Task URL: https://app.clickup.com/t/86a4m6z4j
The QA-format documentation snippet provides detailed information on managing VPN connection limits and user access, which directly relates to the existing 'VPN Setup' and 'Connect to the VPN' sections under the 'Prerequisites' of both AWS and GCP User Guides in the current documentation. Updating these sections with the snippet's content will enrich them with more specific guidance on increasing VPN connections for growing teams, thereby enhancing the utility and comprehensiveness of the documentation for users looking to scale their VPN infrastructure. This approach ensures that relevant, actionable information is easily accessible within the context of existing documentation structure, improving user experience by consolidating related information.