### PR TITLE
update_section: Kubernetes User Guide > Configs and Secrets > Setting Kubernetes Secrets

### DIFF
--- a/kubernetes-overview/configs-and-secrets/setting-kubernetes-secrets.md
+++ b/kubernetes-overview/configs-and-secrets/setting-kubernetes-secrets.md
@@ -1,5 +1,5 @@
 ---
-description: Set and manage Kubernetes Secrets in the DuploCloud Portal.
+description: Set and manage Kubernetes Secrets in the DuploCloud Portal, including troubleshooting format issues.
 ---
 
 # Setting Kubernetes Secrets
@@ -14,6 +14,10 @@ To securely manage sensitive information in your deployment, set and reference K
 4. Click **Add**. The Kubernetes Secret is set.
 
 <figure><img src="../../.gitbook/assets/screenshot-nimbusweb.me-2024.02.14-14_46_22.png" alt=""><figcaption><p><strong>Kubernetes Secrets</strong> page.</p></figcaption></figure>
+
+### Troubleshooting Secret Format Issues
+
+When entering a Kubernetes secret with a private key in Duplo, ensure the data is formatted as key/value pairs with all keys and values as strings. If you encounter format errors, it's likely due to non-string values or incorrect multiline string formatting. Use the `|` character to indicate multiline strings and manually split a single-line private key into multiple lines for compatibility. Matching the format of an existing, working secret can also aid in resolving these issues.
 
 ### Managing Kubernetes Secrets Effectively
 


### PR DESCRIPTION
ClickUp Task URL: https://app.clickup.com/t/86a4jkfhy
The QA-format documentation snippet provides detailed troubleshooting steps for formatting Kubernetes secrets in Duplo, which is a specific technical issue related to Kubernetes usage within the DuploCloud platform. Given the existing documentation structure, there is a section titled 'Configs and Secrets' under the 'Kubernetes User Guide'. This section already covers topics related to managing Kubernetes secrets and configurations. Therefore, incorporating this snippet into the 'Setting Kubernetes Secrets' subsection would enrich the existing content by providing additional, practical troubleshooting guidance for users facing format errors with Kubernetes secrets in Duplo. This action supports the goal of keeping the documentation comprehensive and up-to-date with solutions to specific problems that users may encounter.