### PR TITLE
docs: add integrating providers page with supported provider table

### DIFF
--- a/getting-started/integrating-providers.md
+++ b/getting-started/integrating-providers.md
@@ -1,2 +1,23 @@
 # Integrating Providers
 
+Providers are the external systems and cloud services that DuploCloud AI Suite connects to in order to manage infrastructure, monitor performance, respond to incidents, and interact with your source code. Integrating a provider gives AI agents the context and access they need to perform work on your behalf. This section contains step-by-step instructions for setting up each supported provider.
+
+## Supported Providers
+
+| Category | Provider |
+|---|---|
+| **Cloud Accounts** | Amazon Web Services (AWS) |
+| **Cloud Accounts** | Microsoft Azure |
+| **Cloud Accounts** | Google Cloud Platform (GCP) |
+| **Kubernetes** | Amazon Elastic Kubernetes Service (EKS) |
+| **Kubernetes** | Azure Kubernetes Service (AKS) |
+| **Kubernetes** | Google Kubernetes Engine (GKE) |
+| **Observability** | Datadog |
+| **Observability** | New Relic |
+| **Observability** | Sentry |
+| **Incident Management** | PagerDuty |
+| **Incident Management** | Incident.io |
+| **Source Control** | GitHub |
+| **Source Control** | GitLab |
+| **Source Control** | Bitbucket |
+| **Others** | |


### PR DESCRIPTION
## Summary
- Adds intro paragraph to `getting-started/integrating-providers.md`
- Adds a table of all supported providers organized by category (Cloud Accounts, Kubernetes, Observability, Incident Management, Source Control, Others)
- Each provider is on its own row, ready for individual setup page links

## Test plan
- [ ] Verify page renders correctly in GitBook

🤖 Generated with [Claude Code](https://claude.com/claude-code)