### PR TITLE
Add AI Helpdesk installation guides (AWS, Azure, V1→V2 upgrade)

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -46,6 +46,7 @@
   * [AWS Installation](getting-started/installation/aws-installation.md)
   * [Azure Installation](getting-started/installation/azure-installation.md)
   * [GCP Installation](getting-started/installation/gcp-installation.md)
+  * [Helpdesk V1 to V2 Upgrade](getting-started/installation/v1-to-v2-upgrade.md)
 * [Integrating Providers](getting-started/integrating-providers/README.md)
   * [Amazon Web Services (AWS)](getting-started/integrating-providers/amazon-web-services-aws.md)
   * [Microsoft Azure](getting-started/integrating-providers/microsoft-azure.md)

--- a/getting-started/installation/README.md
+++ b/getting-started/installation/README.md
@@ -14,23 +14,25 @@ DuploCloud deploys the AI Suite into your cloud environment using a Helm chart. 
 
 DuploCloud AI Suite runs on any of the following managed Kubernetes platforms:
 
-| Cloud | Kubernetes Service |
-|---|---|
-| **AWS** | Amazon EKS |
-| **Google Cloud** | GKE |
-| **Azure** | AKS |
+| Cloud | Kubernetes Service | Guide |
+|---|---|---|
+| **AWS** | Amazon EKS | [AWS Installation](aws-installation.md) |
+| **Google Cloud** | GKE | [GCP Installation](gcp-installation.md) |
+| **Azure** | AKS | [Azure Installation](azure-installation.md) |
 
 ---
 
 ## What You Need to Provide
 
-### 1. A Kubernetes Cluster
+### 1. An AWS Account (or Existing Cluster)
 
-You must have a managed Kubernetes cluster running in your cloud account. DuploCloud can assist with cluster setup if one does not already exist.
+The simplest path is to provide DuploCloud with a **fresh, dedicated AWS account**. Our team will create all required infrastructure — VPC, Kubernetes cluster, storage, certificates — from scratch with no risk of disrupting existing workloads.
 
-- **AWS:** Amazon EKS cluster
-- **GCP:** GKE cluster
-- **Azure:** AKS cluster
+If you already have a Kubernetes cluster and prefer to install into an existing account, that is fully supported. DuploCloud deploys into a dedicated namespace and does not modify resources outside of it.
+
+- **AWS:** Amazon EKS (existing cluster, or we create one)
+- **GCP:** GKE (existing cluster required)
+- **Azure:** AKS (existing cluster required)
 
 ### 2. Cloud Infrastructure
 
@@ -104,12 +106,16 @@ All components run inside a dedicated namespace in your cluster and are fully co
 
 ## Access DuploCloud Requires
 
-To perform the installation, our team will need:
+To perform the installation, our team will need admin-level access to your AWS account and Kubernetes cluster. The easiest way to grant this is by running our **CloudFormation template**, which creates a scoped IAM role our team can assume.
 
-- **Kubeconfig access** to your Kubernetes cluster (or a role with permissions to deploy Helm charts into the target namespace)
-- **Read access** to confirm the required infrastructure (load balancer, storage, certificates) is in place
+For AWS, the customer runs the [CloudFormation template](https://us-west-2.console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?templateURL=https://duploservices-ai-access-227120241369.s3.us-west-2.amazonaws.com/aws.yaml) with the following options enabled:
 
-Access requirements are scoped to the installation namespace and can be revoked after deployment is complete.
+- `CreateAdminRole = true` — grants AWS resource creation permissions
+- `CreateEKSAdminRole = true` — grants kubectl access to the cluster (if one exists)
+
+The stack outputs a Role ARN that DuploCloud uses to assume access. This access can be revoked by deleting the CloudFormation stack after installation is complete.
+
+For full details, see the [AWS Installation guide](aws-installation.md).
 
 ---
 

--- a/getting-started/installation/aws-installation.md
+++ b/getting-started/installation/aws-installation.md
@@ -1,2 +1,521 @@
-# AWS Installation
+# AWS Installation Guide
 
+This guide covers everything required to install DuploCloud AI Helpdesk on AWS in **Standalone mode** — running independently in your own EKS cluster, without a DuploCloud master portal.
+
+---
+
+## Overview
+
+The installation deploys the following components into a dedicated namespace in your Kubernetes cluster:
+
+| Component | Description |
+|---|---|
+| **Backend** | ASP.NET Core API server — tickets, projects, agent orchestration |
+| **Frontend** | React web UI served via nginx |
+| **MongoDB** | Embedded database (Kubernetes StatefulSet) |
+| **Web Terminal** | Browser-based terminal for agent command execution |
+| **Duplo Agent** | Claude-powered AI agent runtime |
+| **Ingress (ALB)** | AWS Application Load Balancer routing HTTPS traffic |
+| **Persistent Storage** | EFS-backed shared volume for agent working directories |
+
+All components run entirely within your AWS account. DuploCloud does not operate any shared infrastructure on your behalf.
+
+---
+
+## Deployment Scenarios
+
+### Ideal: Fresh AWS Account (Recommended)
+
+The cleanest path is for the customer to provide a **dedicated, empty AWS account** for DuploCloud AI Helpdesk. This gives our team full control to create all required infrastructure from scratch — VPC, EKS cluster, EFS, security groups, ACM certificates — with no risk of conflicting with existing workloads.
+
+**What the customer does:**
+1. Creates a new AWS account (or sub-account in their AWS Organization)
+2. Runs the [CloudFormation template](#granting-installer-access-via-cloudformation) to create an installer role
+3. Sends DuploCloud the Role ARN and account ID
+
+This is the fastest path to a clean, reproducible installation.
+
+---
+
+### Alternative: Existing Production Account
+
+If the customer prefers to install into an existing AWS account (e.g. alongside other workloads), this is fully supported. DuploCloud Helpdesk deploys into a dedicated Kubernetes namespace and does not modify existing resources outside of that namespace.
+
+**What the customer needs to ensure:**
+- An existing EKS cluster with available node capacity
+- A VPC with public subnets for the ALB
+- Permission to create EFS, security groups, and ACM certificates in the account
+
+> **Sharing a cluster is fine** — multiple applications can coexist in the same EKS cluster. Each runs in its own namespace. Helpdesk deploys into `duploservices-<tenantName>` by default.
+
+---
+
+## Prerequisites
+
+### Tools (DuploCloud Team)
+
+The following must be installed on the machine performing the installation:
+
+| Tool | Version | Install |
+|---|---|---|
+| `aws` CLI | v2+ | `brew install awscli` |
+| `kubectl` | v1.21+ | `brew install kubectl` |
+| `helm` | v3+ | `brew install helm` |
+| `python3` | v3.7+ | Built-in on macOS |
+
+Verify all tools are installed before starting:
+```bash
+aws --version
+kubectl version --client
+helm version --short
+```
+
+---
+
+## What the Customer Must Provide
+
+Before scheduling the installation, collect the following from the customer. Items marked **Required** must be in place before the installation begins.
+
+### 1. AWS Access
+
+| Item | Required | Notes |
+|---|---|---|
+| AWS Account ID | ✅ | 12-digit number (e.g. `774157348504`) |
+| IAM credentials for the installer | ✅ | See [IAM Policy](#iam-policy-for-the-installer) below |
+| Target AWS region | ✅ | e.g. `us-east-1` |
+
+The recommended way to grant access is via the [CloudFormation template](#granting-installer-access-via-cloudformation) — the customer runs it once and shares the output Role ARN. Alternatively, the customer can provide static IAM credentials directly.
+
+### 2. Kubernetes Cluster
+
+| Item | Required | Notes |
+|---|---|---|
+| Existing EKS cluster | ✅ | Kubernetes v1.21+ |
+| Kubeconfig access to the cluster | ✅ | Or an IAM role with `eks:DescribeCluster` to generate one |
+| Available node capacity | ✅ | Minimum 2 nodes, `t3a.large` or larger |
+
+> **No cluster yet?** If the customer does not have an EKS cluster, one must be created before installation. See [IAM Policy Without an Existing EKS Cluster](#without-an-existing-eks-cluster-additional-permissions) for the additional permissions required.
+
+> **Sharing a cluster:** Multiple applications can coexist in the same EKS cluster — each runs in its own namespace. Helpdesk deploys into `duploservices-<tenantName>` by default.
+
+### 3. Domain and DNS
+
+| Item | Required | Notes |
+|---|---|---|
+| Domain or subdomain for the portal | ✅ | e.g. `helpdesk.yourcompany.com` |
+| xterm subdomain | ✅ | e.g. `xterm.helpdesk.yourcompany.com` |
+| Access to DNS provider | ✅ | Route 53, Cloudflare, or equivalent |
+| Existing ACM certificate | Optional | If not available, one will be requested during install |
+
+DNS is configured in **two phases** during the installation:
+1. **Before deployment** — a CNAME record is added to validate the ACM certificate (DNS validation)
+2. **After deployment** — a CNAME or Alias A record points the domain to the provisioned ALB
+
+### 4. Google OAuth Credentials
+
+DuploCloud AI Helpdesk uses Google OAuth for user authentication. Username/password login is not supported.
+
+| Item | Required | Notes |
+|---|---|---|
+| Google OAuth Client ID | ✅ | Created in Google Cloud Console |
+| Google OAuth Client Secret | ✅ | Created in Google Cloud Console |
+
+To create these:
+1. Go to [Google Cloud Console](https://console.cloud.google.com) → **APIs & Services** → **Credentials**
+2. Click **Create Credentials** → **OAuth 2.0 Client ID**
+3. Application type: **Web application**
+4. Add the portal URL to **Authorized JavaScript origins** (e.g. `https://helpdesk.yourcompany.com`)
+5. Add `https://helpdesk.yourcompany.com/auth/callback` to **Authorized redirect URIs**
+6. Copy the Client ID and Client Secret
+
+> Users log in with any Google account (Gmail or Google Workspace). Admin access is controlled by the super-user email list.
+
+### 5. Administrator Emails
+
+| Item | Required | Notes |
+|---|---|---|
+| Super-user email list | ✅ | Comma-separated, e.g. `admin@company.com,ops@company.com` |
+
+These accounts receive full administrative access after installation.
+
+### 6. Slack Integration (Optional)
+
+| Item | Required | Notes |
+|---|---|---|
+| Slack App Token (`xapp-...`) | Optional | Only if enabling Slack backend integration |
+| Slack Bot Token (`xoxb-...`) | Optional | Only if enabling Slack backend integration |
+
+---
+
+## Granting Installer Access via CloudFormation
+
+The easiest way for a customer to grant DuploCloud installation access is to run the existing **DuploCloud Access CloudFormation template**. It takes under 5 minutes and outputs a Role ARN that we use to assume access into the account.
+
+### Step 1 — Deploy the CloudFormation Template
+
+Ask the customer to open this link in the AWS Console (or send it to them):
+
+> [Launch CloudFormation Stack](https://us-west-2.console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?templateURL=https://duploservices-ai-access-227120241369.s3.us-west-2.amazonaws.com/aws.yaml)
+
+You can also [download the template](https://duploservices-ai-access-227120241369.s3.us-west-2.amazonaws.com/aws.yaml) to review before running it.
+
+### Step 2 — Set the Parameters
+
+When deploying the stack, the customer should configure the following parameters:
+
+| Parameter | Value | Notes |
+|---|---|---|
+| `CreateAdminRole` | **true** | Creates `DuploCloud-AWS-Admin` with `AdministratorAccess` — required for installation |
+| `CreateEKSAdminRole` | **true** (if EKS cluster exists) | Creates `DuploCloud-EKS-Admin-<ClusterName>` for kubectl access |
+| `ClusterName` | `<eks-cluster-name>` | Required if `CreateEKSAdminRole` is true |
+| `HelpdeskAccountId` | DuploCloud's account ID | Enables cross-account role assumption |
+| `CreateReadOnlyRole` | false | Not needed for installation |
+| `CreateEKSReadOnlyRole` | false | Not needed for installation |
+
+> **No existing EKS cluster?** Leave `CreateEKSAdminRole` as false. EKS and VPC will be created during the installation using the admin role.
+
+### Step 3 — Share the Role ARN
+
+Once the stack is deployed, the customer shares the `DuploCloud-AWS-Admin` role ARN from the stack **Outputs** tab (e.g. `arn:aws:iam::774157348504:role/DuploCloud-AWS-Admin`).
+
+### Step 4 — Configure the Installer Profile
+
+Add the role to `~/.aws/config` on the installer machine:
+
+```ini
+[profile helpdesk-installer]
+role_arn = arn:aws:iam::<CUSTOMER_ACCOUNT_ID>:role/DuploCloud-AWS-Admin
+source_profile = <your-base-profile>
+region = <target-region>
+```
+
+Verify it works:
+```bash
+aws sts get-caller-identity --profile helpdesk-installer
+```
+
+---
+
+### Reference: Minimum IAM Policies (Manual Alternative)
+
+If the customer cannot run CloudFormation, the following policies can be created manually. Use these as a reference or share them with the customer's AWS administrator.
+
+**With an existing EKS cluster:**
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "STSCheck",
+      "Effect": "Allow",
+      "Action": ["sts:GetCallerIdentity"],
+      "Resource": "*"
+    },
+    {
+      "Sid": "EKSAccess",
+      "Effect": "Allow",
+      "Action": ["eks:DescribeCluster", "eks:ListClusters"],
+      "Resource": "*"
+    },
+    {
+      "Sid": "EC2ReadOnly",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeVpcs", "ec2:DescribeSubnets",
+        "ec2:DescribeSecurityGroups", "ec2:DescribeInstances"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "EC2SecurityGroupWrite",
+      "Effect": "Allow",
+      "Action": ["ec2:CreateSecurityGroup", "ec2:AuthorizeSecurityGroupIngress"],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ACM",
+      "Effect": "Allow",
+      "Action": ["acm:ListCertificates", "acm:RequestCertificate", "acm:DescribeCertificate"],
+      "Resource": "*"
+    },
+    {
+      "Sid": "EFS",
+      "Effect": "Allow",
+      "Action": [
+        "efs:CreateFileSystem", "efs:DescribeFileSystems",
+        "efs:DescribeMountTargets", "efs:TagResource"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+**Without an existing EKS cluster** — add these additional statements to the policy above:
+
+```json
+{
+  "Sid": "EKSCreate",
+  "Effect": "Allow",
+  "Action": [
+    "eks:CreateCluster", "eks:CreateNodegroup", "eks:UpdateClusterConfig",
+    "eks:UpdateNodegroupConfig", "eks:TagResource", "eks:DescribeNodegroup",
+    "eks:ListNodegroups", "eks:DescribeUpdate"
+  ],
+  "Resource": "*"
+},
+{
+  "Sid": "EC2VPCCreate",
+  "Effect": "Allow",
+  "Action": [
+    "ec2:CreateVpc", "ec2:CreateSubnet", "ec2:CreateInternetGateway",
+    "ec2:AttachInternetGateway", "ec2:CreateRouteTable", "ec2:CreateRoute",
+    "ec2:AssociateRouteTable", "ec2:AllocateAddress", "ec2:CreateNatGateway",
+    "ec2:ModifyVpcAttribute", "ec2:ModifySubnetAttribute", "ec2:CreateTags",
+    "ec2:DescribeRouteTables", "ec2:DescribeInternetGateways",
+    "ec2:DescribeNatGateways", "ec2:DescribeAddresses", "ec2:DescribeAvailabilityZones"
+  ],
+  "Resource": "*"
+},
+{
+  "Sid": "IAMForEKS",
+  "Effect": "Allow",
+  "Action": [
+    "iam:CreateRole", "iam:AttachRolePolicy", "iam:DetachRolePolicy",
+    "iam:PassRole", "iam:GetRole", "iam:ListAttachedRolePolicies",
+    "iam:CreateOpenIDConnectProvider", "iam:GetOpenIDConnectProvider"
+  ],
+  "Resource": "*"
+},
+{
+  "Sid": "AutoScaling",
+  "Effect": "Allow",
+  "Action": [
+    "autoscaling:CreateAutoScalingGroup", "autoscaling:DescribeAutoScalingGroups",
+    "autoscaling:UpdateAutoScalingGroup", "autoscaling:CreateLaunchConfiguration",
+    "autoscaling:DescribeLaunchConfigurations"
+  ],
+  "Resource": "*"
+}
+```
+
+---
+
+## Setting Up an AWS Profile
+
+### Option A — Static IAM Credentials
+
+If the customer provides an access key and secret:
+
+```bash
+aws configure --profile <profile-name>
+```
+
+You will be prompted for:
+- AWS Access Key ID
+- AWS Secret Access Key
+- Default region (e.g. `us-east-1`)
+- Output format (`json`)
+
+Verify the profile works:
+```bash
+aws sts get-caller-identity --profile <profile-name>
+```
+
+### Option B — IAM Role Assumption
+
+If the customer provides a role ARN for you to assume from an existing profile, add this to `~/.aws/config`:
+
+```ini
+[profile helpdesk-installer]
+role_arn = arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>
+source_profile = <your-base-profile>
+region = us-east-1
+```
+
+The customer's IAM role must include your IAM user/identity as a trusted principal in its trust policy:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::<YOUR_ACCOUNT_ID>:user/<YOUR_USERNAME>"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+```
+
+Verify role assumption:
+```bash
+aws sts get-caller-identity --profile helpdesk-installer
+```
+
+---
+
+## Setting Up kubectl Access
+
+Once AWS credentials are configured, generate a kubeconfig for the target EKS cluster:
+
+```bash
+aws eks update-kubeconfig \
+  --name <cluster-name> \
+  --region <region> \
+  --profile <profile-name> \
+  --alias <friendly-name>
+```
+
+Verify connectivity:
+```bash
+kubectl get nodes
+```
+
+You should see the cluster nodes listed with `Ready` status before proceeding.
+
+---
+
+## Installation Methods
+
+There are two ways to install DuploCloud AI Helpdesk on AWS.
+
+---
+
+### Method 1 — Guided Installation via Claude Code Skill (Recommended)
+
+The `helpdesk-install-skill` is a Claude Code skill that guides you interactively through the entire installation. It handles AWS resource discovery, values file generation, and Helm deployment — prompting you at each step and validating inputs against live AWS data.
+
+**Prerequisites:**
+- Claude Code CLI installed (`npm install -g @anthropic-ai/claude-code`)
+- The `ai-ops` repository cloned locally (the skill lives in `.claude/skills/`)
+
+**Start the installation:**
+
+```bash
+cd /path/to/ai-ops
+claude
+```
+
+Then invoke the skill:
+
+```
+/helpdesk-install-skill
+```
+
+The skill will walk you through:
+
+1. **Prerequisites check** — verifies `aws`, `kubectl`, `helm` are installed
+2. **AWS profile selection** — selects and validates credentials
+3. **Kubernetes context selection** — selects and verifies cluster connectivity
+4. **Deployment mode** — select `STANDALONE`
+5. **Configuration collection** — gathers all required values in grouped prompts
+6. **AWS resource discovery** — queries your account for existing VPCs, subnets, security groups, certificates, and storage classes; creates missing resources where needed
+7. **Values file generation** — produces `<customerName>-values.yaml` with all substituted values (secrets auto-generated)
+8. **Helm deployment** — deploys via local `helm install` or saves values file for manual deployment
+9. **Slack notification** — notifies `#customer-ai-deploys` on completion
+
+> **Note:** Add `*-values.yaml` to `.gitignore` — the generated file contains plaintext secrets including MongoDB password and JWT secret.
+
+---
+
+### Method 2 — Manual Helm Deployment
+
+If you already have a values file or prefer to deploy manually:
+
+**Step 1 — Fetch the latest chart version:**
+
+```bash
+helm pull oci://quay.io/duplocloud/helpdesk --untar --untardir /tmp/helpdesk-chart
+grep "^version:" /tmp/helpdesk-chart/helpdesk/Chart.yaml
+```
+
+**Step 2 — Create your values file** based on the template in `ai-ops/.claude/skills/helpdesk-install-skill/values-template.yaml`, substituting all `{{placeholder}}` values.
+
+**Step 3 — Deploy:**
+
+```bash
+helm upgrade --install helpdesk oci://quay.io/duplocloud/helpdesk \
+  --version <chart-version> \
+  --namespace duploservices-<tenantName> \
+  --create-namespace \
+  --values <customerName>-values.yaml \
+  --wait \
+  --timeout 10m
+```
+
+**Step 4 — Verify:**
+
+```bash
+kubectl get pods -n duploservices-<tenantName>
+kubectl get ingress -n duploservices-<tenantName>
+```
+
+---
+
+## Post-Installation DNS Setup
+
+After the ALB is provisioned, point your domain to it:
+
+**Get the ALB DNS name:**
+
+```bash
+kubectl get ingress -n duploservices-<tenantName> \
+  -o jsonpath='{.items[0].status.loadBalancer.ingress[0].hostname}'
+```
+
+**Add a DNS record at your provider:**
+
+| Type | Name | Value |
+|---|---|---|
+| CNAME | `helpdesk.yourcompany.com` | `<alb-dns>.us-east-1.elb.amazonaws.com` |
+| CNAME | `xterm.helpdesk.yourcompany.com` | `<alb-dns>.us-east-1.elb.amazonaws.com` |
+
+If using **Route 53**, you can use an Alias A record instead of a CNAME, which avoids the extra DNS hop.
+
+---
+
+## Connecting AWS to the Helpdesk (Post-Installation)
+
+Once the portal is live, you can connect AWS accounts to it so AI agents can query and manage your infrastructure. This uses the **AWS Cloud Provider** feature inside the Helpdesk.
+
+> Use the [CloudFormation Template](https://us-west-2.console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?templateURL=https://duploservices-ai-access-227120241369.s3.us-west-2.amazonaws.com/aws.yaml) to automatically create the IAM role and Kubernetes credentials needed to connect an AWS account. You can also [download the template](https://duploservices-ai-access-227120241369.s3.us-west-2.amazonaws.com/aws.yaml) for review. For more details, see the [GitHub repo](https://github.com/duplocloud/duplocloud-helpdesk-access).
+
+There are two authentication methods:
+
+### IAM Role (Recommended)
+
+1. Log in to the Helpdesk portal → **Providers** → select your tenant → **Cloud** tab → **+ Add**
+2. Fill in **Name**, **Type** = `AWS`, **Account ID**
+3. Go to the **Credentials** tab → **+ Add** → **Credential Type** = `IAM Role`
+4. Enter the **IAM Role ARN** to assume
+5. Add a **Scope** — select region and resource types
+6. Use the scope in a ticket to have the agent act on your AWS account
+
+> The IAM role must include the DuploCloud service account as a trusted principal in its trust policy.
+
+### Access Key
+
+1. Follow steps 1–2 above to create a provider
+2. Go to **Credentials** → **+ Add** → **Credential Type** = `Access Key`
+3. Enter the Access Key ID and Secret Access Key
+4. Add a **Scope** and use it in tickets
+
+For full step-by-step screenshots, see the [AWS Provider guide](../integrating-providers/amazon-web-services-aws.md).
+
+---
+
+## Troubleshooting
+
+| Issue | Resolution |
+|---|---|
+| `aws sts get-caller-identity` fails | Credentials expired or profile misconfigured — re-run `aws configure --profile <name>` |
+| `kubectl get nodes` fails | Run `aws eks update-kubeconfig --name <cluster> --region <region> --profile <profile>` |
+| EFS mount targets not available | Wait up to 10 minutes — EFS creates one mount target per subnet |
+| ALB not provisioned | Verify AWS Load Balancer Controller is installed: `kubectl get pods -n kube-system | grep aws-load-balancer` |
+| Pods stuck in `Pending` | Check EFS CSI driver: `kubectl get pods -n kube-system | grep efs` |
+| Helm timeout | Check pod events: `kubectl describe pods -n duploservices-<tenantName>` and `kubectl get events -n duploservices-<tenantName> --sort-by='.lastTimestamp'` |
+| ACM cert stuck in `PENDING_VALIDATION` | DNS validation CNAME records have not been added or have not propagated yet |

--- a/getting-started/installation/azure-installation.md
+++ b/getting-started/installation/azure-installation.md
@@ -1,2 +1,326 @@
-# Azure Installation
+# Azure Installation Guide
 
+This guide covers installing DuploCloud AI Helpdesk on **Azure Kubernetes Service (AKS)** using Terraform.
+
+> **Note:** The guided skill-based installation (like the AWS `helpdesk-install-skill`) is currently in development for Azure. The current method uses Terraform automation. Contact your DuploCloud account team to schedule an installation.
+
+---
+
+## What Gets Deployed
+
+Terraform provisions the following resources in order:
+
+```
+AKS Node Pool → Storage Class (conditional) → Namespace → ConfigMap → Helm Release
+```
+
+| Component | Azure Resource |
+|---|---|
+| **Backend** | ASP.NET Core API — tickets, projects, agent orchestration |
+| **Frontend** | React web UI served via nginx |
+| **MongoDB** | Kubernetes StatefulSet with Azure Blob NFS storage |
+| **Web Terminal** | Browser-based terminal for agent command execution |
+| **Duplo Agent** | Claude-powered AI agent (connects to Azure AI Foundry) |
+| **Ingress** | Azure Application Gateway routing HTTPS traffic |
+| **Persistent Storage** | Azure Blob NFS (`azureblob-nfs-premium`) for backend and agent |
+
+All components run inside a dedicated namespace in your AKS cluster within your Azure subscription.
+
+---
+
+## Prerequisites
+
+### Tools (DuploCloud Team)
+
+| Tool | Version | Install |
+|---|---|---|
+| `git` | Any | `brew install git` |
+| `terraform` | >= 1.5.0 | `brew install terraform` |
+| `azure-cli` | >= 2.50 | `brew install azure-cli` |
+| `kubectl` | >= 1.27 | `brew install kubectl` |
+| `helm` | >= 3.12 | `brew install helm` |
+
+### Azure Access Required
+
+| Item | Required | Notes |
+|---|---|---|
+| Azure **Contributor** role on the AKS resource group | ✅ | Required for node pool creation |
+| Kubernetes **cluster-admin** RBAC | ✅ | Required for namespace and storage class creation |
+| Access to `oci://quay.io/duplocloud` Helm registry | ✅ | No credentials needed — public OCI registry |
+
+---
+
+## What the Customer Must Provide
+
+Collect the following before starting:
+
+| Item | Required | Notes |
+|---|---|---|
+| Azure Subscription ID | ✅ | e.g. `82300ad4-6ef0-48ef-acee-a4d9e495e5a4` |
+| Resource group containing the AKS cluster | ✅ | e.g. `duploinfra-ai` |
+| AKS cluster name | ✅ | e.g. `ai` |
+| Azure region | ✅ | e.g. `westus`, `eastus` |
+| Azure AI Foundry resource name | ✅ | The subdomain before `.services.ai.azure.com` |
+| Azure AI Foundry API key | ✅ | From Keys and Endpoint in the Azure portal |
+| Portal domain | ✅ | e.g. `helpdesk.yourcompany.com` |
+| xterm subdomain | ✅ | e.g. `helpdesk-xterm.yourcompany.com` |
+| Internal agent hostname | ✅ | e.g. `helpdesk-agent.yourcompany.com` |
+| Google OAuth Client ID | ✅ | See [Google OAuth Credentials](#google-oauth-credentials) |
+| Google OAuth Client Secret | ✅ | See [Google OAuth Credentials](#google-oauth-credentials) |
+| Super-user email list | ✅ | Comma-separated admin emails |
+| SSL certificate name on App Gateway | ✅ | The name of the cert configured in Azure Application Gateway |
+
+---
+
+## Google OAuth Credentials
+
+DuploCloud AI Helpdesk uses Google OAuth for user authentication. Username/password login is not supported.
+
+To create a Google OAuth client:
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com) → **APIs & Services** → **Credentials**
+2. Click **Create Credentials** → **OAuth 2.0 Client ID**
+3. Application type: **Web application**
+4. Add the portal URL to **Authorized JavaScript origins** (e.g. `https://helpdesk.yourcompany.com`)
+5. Add `https://helpdesk.yourcompany.com/auth/callback` to **Authorized redirect URIs**
+6. Copy the **Client ID** and **Client Secret**
+
+---
+
+## Azure AI Foundry Configuration
+
+DuploCloud AI Helpdesk uses **Azure AI Foundry** as the AI model backend. The API key is injected into the `duploAgent` component at deploy time.
+
+### Finding Your Azure AI Foundry Details
+
+1. Go to **Azure Portal → Azure AI Foundry**
+2. Note the **Resource Name** — this is the subdomain before `.services.ai.azure.com` (e.g. if your endpoint is `https://my-foundry.services.ai.azure.com/anthropic`, the resource name is `my-foundry`)
+3. Go to **Keys and Endpoint** and copy the **API Key**
+
+### How It's Configured
+
+The API key and endpoint URL are injected into the `duploAgent` pod as environment variables:
+
+```yaml
+duploAgent:
+  extraEnv:
+    - name: AZURE_API_KEY
+      value: "<your-api-key>"
+    - name: AZURE_BASE_URL
+      value: "https://<resource-name>.services.ai.azure.com/anthropic"
+```
+
+These values are set via Terraform sensitive variables — the API key is never stored in `terraform.tfvars`.
+
+> **Managed Identity (future):** Managed Identity authentication is also supported using `AZURE_CLIENT_ID` instead of `AZURE_API_KEY`. Contact your DuploCloud account team if your Azure setup uses Managed Identity.
+
+---
+
+## Step-by-Step Deployment
+
+### Step 1 — Clone the Repository
+
+```bash
+git clone git@github.com:duplocloud-internal/azure-ai-hd-deployment-automation.git
+cd azure-ai-hd-deployment-automation/helpdesk-terraform
+```
+
+### Step 2 — Log In to Azure and Get Cluster Credentials
+
+```bash
+az login
+az account set --subscription "<subscription_id>"
+az aks get-credentials --resource-group "<resource_group>" --name "<cluster_name>" --admin
+```
+
+Find your `kube_context` and `kube_config_path` for use in the next step:
+
+```bash
+kubectl config current-context   # e.g. "ai-admin"
+echo $KUBECONFIG                 # if set, use this path; if empty, default is ~/.kube/config
+```
+
+Verify cluster access:
+```bash
+kubectl get nodes
+```
+
+> **Credential expiry:** If you get auth failures later, re-run `az aks get-credentials --overwrite-existing`.
+
+### Step 3 — Check if Storage Class Exists
+
+```bash
+kubectl get storageclass azureblob-nfs-premium
+```
+
+- **Found** → set `create_storage_class = false` in `terraform.tfvars`
+- **Not found** → set `create_storage_class = true`
+
+### Step 4 — Edit `terraform.tfvars`
+
+Open `terraform.tfvars` and fill in all values. **Do not put secrets here** — those go in Step 5.
+
+```hcl
+# Azure infrastructure
+subscription_id  = "<subscription-id>"
+resource_group   = "<resource-group>"
+aks_cluster_name = "<cluster-name>"
+location         = "westus"              # Azure region
+
+# Kubernetes access
+kube_config_path = "~/.kube/config"
+kube_context     = "<from Step 2>"       # e.g. "ai-admin"
+
+# Tenant
+tenant_name = "<tenant>"                 # e.g. "helpdesk"
+namespace   = "duploservices-<tenant>"
+
+# Node pool
+node_pool_name          = "helpdesk"
+node_pool_vm_size       = "Standard_D2s_v3"
+node_pool_min_count     = 2
+node_pool_max_count     = 3
+node_pool_desired_count = 2
+
+# Azure AI Foundry
+azure_foundry_resource_name = "<resource-name>"   # subdomain only, no URL
+
+# Storage class
+create_storage_class = false   # or true — from Step 3
+
+# Helm chart version
+helm_version = "0.1.51"
+
+# URLs
+frontend_url      = "https://helpdesk.<domain>"
+frontend_hostname = "helpdesk.<domain>"
+xterm_url         = "https://helpdesk-xterm.<domain>"
+internal_hostname = "helpdesk-agent.<domain>"
+
+# Admin access
+auth_super_users = "admin@<domain>,ops@<domain>"
+```
+
+### Step 5 — Export Sensitive Variables
+
+These **must never** be stored in `terraform.tfvars`. Export them as environment variables before running Terraform:
+
+```bash
+export TF_VAR_google_client_id="<google-client-id>"
+export TF_VAR_google_client_secret="<google-client-secret>"
+export TF_VAR_jwt_secret="$(openssl rand -base64 32 | tr -dc 'A-Za-z0-9' | head -c 32)"
+export TF_VAR_mongodb_root_password="$(openssl rand -base64 24 | tr -dc 'A-Za-z0-9' | head -c 20)"
+export TF_VAR_azure_foundry_api_key="<azure-ai-foundry-api-key>"
+```
+
+### Step 6 — Deploy
+
+```bash
+terraform init
+terraform plan -out=plan.tfplan
+terraform apply plan.tfplan
+```
+
+Deployment takes approximately **5–10 minutes**. The node pool provisioning is the main bottleneck.
+
+### Step 7 — Verify
+
+```bash
+kubectl -n duploservices-<tenant> get pods
+kubectl -n duploservices-<tenant> get ingress
+helm -n duploservices-<tenant> list
+```
+
+All pods should reach `Running` status before proceeding.
+
+### Step 8 — Configure DNS
+
+Get the App Gateway IP from Terraform output:
+
+```bash
+terraform output app_gateway_ip
+```
+
+Add the following DNS records at your provider:
+
+| Record Type | Name | Points To |
+|---|---|---|
+| A | `helpdesk.<domain>` | App Gateway public IP |
+| A | `helpdesk-xterm.<domain>` | App Gateway public IP |
+| A | `helpdesk-agent.<domain>` | App Gateway **private** IP |
+
+> The internal agent hostname uses the App Gateway's **private** IP — it is not publicly accessible.
+
+---
+
+## Updating a Deployment
+
+To update an existing deployment (e.g. new Helm chart version, config change):
+
+```bash
+cd azure-ai-hd-deployment-automation/helpdesk-terraform
+git pull origin main
+
+# Edit terraform.tfvars as needed
+# Re-export any changed sensitive variables
+
+terraform plan -out=plan.tfplan
+terraform apply plan.tfplan
+```
+
+---
+
+## Multi-Client Deployments
+
+Each client needs its own tfvars file and Terraform state. Use `-var-file` to target a specific client:
+
+```bash
+terraform plan -var-file=envs/clientA.tfvars -out=plan.tfplan
+terraform apply plan.tfplan
+```
+
+> Without a remote backend, deploying a different client from the same directory will overwrite local state. Use a remote backend (Azure Storage or Terraform Cloud) for production multi-client setups.
+
+---
+
+## Destroying a Deployment
+
+```bash
+terraform destroy
+```
+
+> **Warning:** MongoDB data will be lost if the persistent volume reclaim policy is `Delete`. Back up data before destroying.
+
+---
+
+## Ingress and SSL
+
+Azure deployments use the **Azure Application Gateway** as the ingress controller. SSL termination is handled at the gateway using a pre-configured certificate.
+
+The ingress annotations used:
+
+```yaml
+ingress:
+  className: azure-application-gateway
+  annotations:
+    appgw.ingress.kubernetes.io/appgw-ssl-certificate: duplo   # cert name on App Gateway
+    appgw.ingress.kubernetes.io/ssl-redirect: "true"
+    appgw.ingress.kubernetes.io/request-timeout: "300"
+    appgw.ingress.kubernetes.io/health-probe-status-codes: 200-503
+```
+
+The SSL certificate (`duplo` in the example above) must already be configured on the Azure Application Gateway before deployment. The customer must provide the certificate name.
+
+---
+
+## Troubleshooting
+
+| Error | Resolution |
+|---|---|
+| `403 — cannot create namespaces/storageclasses` | Ensure `cluster-admin` RBAC is granted, or set `create_storage_class = false` |
+| Helm timeout (>600s) | Node pool still scaling — run `kubectl get nodes -w` to monitor |
+| `StorageClass already exists` | Set `create_storage_class = false` in tfvars |
+| Provider auth failure | Re-run `az aks get-credentials --overwrite-existing`, verify `kube_context` in tfvars |
+| `Namespace already exists` | Run `terraform import kubernetes_namespace_v1.helpdesk <namespace>` |
+| Pods stuck in `Pending` | Check node pool status in Azure portal — node provisioning may still be in progress |
+| 502 from App Gateway | Check pod health: `kubectl describe pods -n <namespace>` and verify health probe status codes annotation |

--- a/getting-started/installation/gcp-installation.md
+++ b/getting-started/installation/gcp-installation.md
@@ -1,2 +1,3 @@
 # GCP Installation
 
+> **Coming Soon** — This page is currently being updated. For installation assistance on Google Cloud (GKE), please contact your DuploCloud account team directly.

--- a/getting-started/installation/v1-to-v2-upgrade.md
+++ b/getting-started/installation/v1-to-v2-upgrade.md
@@ -1,0 +1,478 @@
+# Helpdesk V1 to V2 Upgrade Guide
+
+This guide covers upgrading from **Helpdesk V1** (the `Duplo.ai.studio` Windows service running on the DuploCloud master VM) to **Helpdesk V2** (a fully Kubernetes-native deployment managed via Helm, running inside a DuploCloud tenant).
+
+This upgrade follows the **Integrated** deployment mode — V2 is connected to and managed by your existing DuploCloud master portal.
+
+---
+
+## What Changes
+
+| | V1 | V2 |
+|---|---|---|
+| **Deployment** | Windows service on the master VM | Helm chart in a Kubernetes tenant |
+| **Infrastructure** | Runs on the master host | Dedicated EKS nodes (ASG) |
+| **Storage** | Local disk on master VM | EFS (Elastic File System) |
+| **Load balancing** | Front door proxy on master VM | AWS ALB via Kubernetes Ingress |
+| **Updates** | Manual service reinstall | `helm upgrade` |
+| **Observability** | Windows Event Viewer | Kubernetes pod logs, DuploCloud portal |
+
+V2 runs entirely within your AWS account inside a DuploCloud tenant. The master portal's front door proxy is updated to route `/v1/aistudio/*` traffic to the new V2 endpoint.
+
+---
+
+## Prerequisites
+
+### Tools (DuploCloud Team)
+
+| Tool | Version | Install |
+|---|---|---|
+| `aws` CLI | v2+ | `brew install awscli` |
+| `kubectl` | v1.21+ | `brew install kubectl` |
+| `helm` | v3+ | `brew install helm` |
+| `python3` | v3.7+ | Built-in on macOS |
+
+### Access Required
+
+| Item | Required | Notes |
+|---|---|---|
+| DuploCloud master URL | ✅ | e.g. `https://duplo.yourcompany.com` — no trailing slash |
+| DuploCloud API token | ✅ | Admin-level token from the master portal |
+| AWS credentials for the master account | ✅ | See [Setting Up AWS Credentials](#setting-up-aws-credentials) below |
+| `kubectl` access to the master EKS cluster | ✅ | See [Setting Up kubectl Access](#setting-up-kubectl-access) below |
+| SSH / RDP access to the master VM | Optional | Required for V1 cleanup if SSM is not available |
+
+### Information to Collect from the Customer
+
+Before starting, gather the following:
+
+| Item | Notes |
+|---|---|
+| DuploCloud portal URL | e.g. `https://duplo.yourcompany.com` |
+| Admin API token | Generated in the portal under **Administrator → API Tokens** |
+| Target AWS region | e.g. `us-east-1` |
+| Portal domain for V2 Helpdesk | e.g. `helpdesk.yourcompany.com` |
+| xterm subdomain | e.g. `xterm.helpdesk.yourcompany.com` |
+| Google OAuth Client ID and Secret | See [Google OAuth Credentials](#google-oauth-credentials) below |
+| Super-user email list | Comma-separated admin emails |
+| Slack App Token + Bot Token | Only if enabling Slack integration |
+| EC2 Instance ID of the master VM | For V1 service cleanup via SSM |
+
+---
+
+## Setting Up AWS Credentials
+
+### Option A — Static IAM Credentials
+
+If the customer provides an AWS access key and secret, configure a named profile:
+
+```bash
+aws configure --profile <profile-name>
+```
+
+You will be prompted for:
+- AWS Access Key ID
+- AWS Secret Access Key
+- Default region (e.g. `us-east-1`)
+- Output format (`json`)
+
+Verify the profile works:
+```bash
+aws sts get-caller-identity --profile <profile-name>
+```
+
+### Option B — IAM Role Assumption (Recommended)
+
+The customer can create an IAM role for DuploCloud to assume. Add this to `~/.aws/config`:
+
+```ini
+[profile helpdesk-installer]
+role_arn = arn:aws:iam::<ACCOUNT_ID>:role/DuploCloud-AWS-Admin
+source_profile = <your-base-profile>
+region = us-east-1
+```
+
+The customer's IAM role trust policy must include your IAM user as an allowed principal:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::<YOUR_ACCOUNT_ID>:user/<YOUR_USERNAME>"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+```
+
+The easiest way for a customer to create this role is to run the **DuploCloud Access CloudFormation template** with `CreateAdminRole = true` and `CreateEKSAdminRole = true`. The stack outputs a Role ARN you can use directly.
+
+Verify role assumption works:
+```bash
+aws sts get-caller-identity --profile helpdesk-installer
+```
+
+---
+
+## Setting Up kubectl Access
+
+Once AWS credentials are configured, generate a kubeconfig entry for the EKS cluster:
+
+```bash
+aws eks update-kubeconfig \
+  --name <cluster-name> \
+  --region <region> \
+  --profile <profile-name> \
+  --alias <friendly-name>
+```
+
+Verify connectivity:
+```bash
+kubectl get nodes
+```
+
+All nodes should show `Ready` status before proceeding with the upgrade.
+
+---
+
+## Google OAuth Credentials
+
+DuploCloud AI Helpdesk uses Google OAuth for user authentication. Username/password login is not supported.
+
+To create a Google OAuth client:
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com) → **APIs & Services** → **Credentials**
+2. Click **Create Credentials** → **OAuth 2.0 Client ID**
+3. Application type: **Web application**
+4. Add the portal URL to **Authorized JavaScript origins** (e.g. `https://helpdesk.yourcompany.com`)
+5. Add `https://helpdesk.yourcompany.com/auth/callback` to **Authorized redirect URIs**
+6. Copy the **Client ID** and **Client Secret**
+
+Users log in with any Google account (Gmail or Google Workspace). Admin access is controlled by the super-user email list you provide.
+
+---
+
+## Upgrade Overview
+
+The upgrade has five phases:
+
+1. **Deploy V2** — provision a new DuploCloud tenant with EKS nodes, EFS storage, and deploy the V2 Helm chart
+2. **Update front door proxy** — point the DuploCloud master portal's proxy to the V2 endpoint
+3. **Enable AI feature flag** — verify `ENABLE_AI` is set in the master portal system settings
+4. **Clean up V1** — stop, kill, and delete the `Duplo.ai.studio` Windows service from the master VM
+5. **Update DNS** — point the portal domain to the new V2 ALB
+
+---
+
+## Phase 1 — Deploy Helpdesk V2
+
+### Option A — Guided Installation via Claude Code Skill (Recommended)
+
+The `helpdesk-install-skill` in the `ai-ops` repository handles the entire V2 deployment interactively.
+
+```bash
+cd /path/to/ai-ops
+claude
+```
+
+Invoke the skill:
+
+```
+/helpdesk-install-skill
+```
+
+When prompted for deployment mode, select **INTEGRATED**. The skill will:
+
+1. Verify prerequisites (`aws`, `kubectl`, `helm`)
+2. Confirm AWS profile and Kubernetes context
+3. Collect DuploCloud master URL, API token, and all configuration values
+4. Provision a DuploCloud tenant (new or existing)
+5. Create an ASG and wait for worker nodes to become Ready (~10 min)
+6. Create an EFS filesystem and wait for mount targets (~10 min)
+7. Install the EFS CSI driver if not already present
+8. Create the EFS-backed StorageClass
+9. Discover or request an ACM certificate
+10. Discover subnets and security groups from the DuploCloud plan
+11. Generate `<customerName>-values.yaml` with all substituted values
+12. Deploy the Helm release via DuploCloud Flux API or local Helm
+
+Once deployment succeeds, the skill automatically proceeds to Phases 2–4 below.
+
+> **Note:** Add `*-values.yaml` to `.gitignore` — the file contains plaintext secrets.
+
+---
+
+### Option B — Manual Helm Deployment
+
+If deploying manually, complete the following infrastructure steps first via the DuploCloud portal or API, then deploy with Helm.
+
+#### Step 1 — Create a Tenant
+
+In the DuploCloud portal → **Administrator → Tenants** → **+ Add Tenant**, create a new tenant (e.g. `helpdesk`) under your infrastructure plan.
+
+#### Step 2 — Create Worker Nodes
+
+In the tenant → **Cloud Services → Hosts**, create an ASG:
+
+| Setting | Value |
+|---|---|
+| Instance type | `t3a.large` (minimum) |
+| Desired capacity | 1 |
+| Min / Max | 1 / 2 |
+| Autoscaling | Enabled |
+| OS | Amazon Linux 2023 |
+| Encryption | KMS encrypted |
+
+Wait until nodes show **Ready** in the portal before proceeding.
+
+#### Step 3 — Create EFS Storage
+
+In the tenant → **Cloud Services → Storage → EFS** → **+ Add**:
+
+| Setting | Value |
+|---|---|
+| Name | `ai-storage` |
+| Encrypted | Yes |
+| Performance mode | General Purpose |
+| Throughput mode | Elastic |
+
+Wait until all mount targets show **Available** (~5–10 min).
+
+#### Step 4 — Create StorageClass
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: duploservices-helpdesk-ai-storage
+  labels:
+    duplocloud.net/owner: duplo
+    duplocloud.net/tenantname: helpdesk
+provisioner: efs.csi.aws.com
+parameters:
+  basePath: /dynamic_provisioning
+  directoryPerms: '700'
+  fileSystemId: <efs-filesystem-id>
+  gidRangeEnd: '10000'
+  gidRangeStart: '1000'
+  provisioningMode: efs-ap
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+EOF
+```
+
+#### Step 5 — Deploy via Helm
+
+```bash
+helm upgrade --install helpdesk oci://quay.io/duplocloud/helpdesk \
+  --version <chart-version> \
+  --namespace duploservices-helpdesk \
+  --create-namespace \
+  --values <customerName>-values.yaml \
+  --wait \
+  --timeout 10m
+```
+
+Verify:
+
+```bash
+kubectl get pods -n duploservices-helpdesk
+kubectl get ingress -n duploservices-helpdesk
+```
+
+---
+
+## Phase 2 — Update Front Door Proxy
+
+Once V2 pods are running, update the DuploCloud master portal's front door proxy to route traffic to the new endpoint.
+
+```bash
+curl -s -X POST \
+  -H "Authorization: Bearer $DUPLO_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$DUPLO_MASTER_URL/v3/admin/frontdoor/config" \
+  -d "{\"AiStudioEndpoint\":\"$AI_STUDIO_BASE_URL\"}"
+```
+
+> ⚠️ **The portal will be briefly unavailable (15–30 seconds)** while the front door container restarts to apply the new configuration.
+
+Restart the front door container on the master VM via SSM:
+
+```bash
+# Send restart command
+COMMAND_ID=$(aws ssm send-command \
+  --instance-ids "$MASTER_INSTANCE_ID" \
+  --document-name "AWS-RunShellScript" \
+  --parameters 'commands=["docker rm -f duplo-frontdoor"]' \
+  --query "Command.CommandId" --output text)
+
+# Poll for completion
+aws ssm get-command-invocation \
+  --command-id "$COMMAND_ID" \
+  --instance-id "$MASTER_INSTANCE_ID" \
+  --query "{Status:Status,Output:StandardOutputContent}" \
+  --output json
+```
+
+If SSM is not available, RDP into the master VM and run:
+
+```bash
+docker rm -f duplo-frontdoor
+```
+
+Docker will automatically restart the container with the updated configuration.
+
+Verify the container is back up:
+
+```bash
+aws ssm send-command \
+  --instance-ids "$MASTER_INSTANCE_ID" \
+  --document-name "AWS-RunShellScript" \
+  --parameters 'commands=["docker ps | grep duplo-frontdoor"]'
+```
+
+---
+
+## Phase 3 — Enable AI Feature Flag
+
+Verify the `ENABLE_AI` system flag is enabled in the master portal.
+
+**Check current status:**
+
+```bash
+curl -s \
+  -H "Authorization: Bearer $DUPLO_TOKEN" \
+  "$DUPLO_MASTER_URL/v3/admin/systemSettings/config" \
+  | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+flag = [x for x in data if x.get('Type')=='Flags' and x.get('Key')=='ENABLE_AI']
+print(flag[0].get('Value','not set') if flag else 'not found')
+"
+```
+
+**Enable if not already set:**
+
+```bash
+curl -s -X POST \
+  -H "Authorization: Bearer $DUPLO_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$DUPLO_MASTER_URL/v3/admin/systemSettings/config" \
+  --data-raw '{"Type":"Flags","Key":"ENABLE_AI","Value":"true"}'
+```
+
+Alternatively, enable via the portal: **Administrator → System Settings → System Config** → set `ENABLE_AI` to `true`.
+
+---
+
+## Phase 4 — Clean Up Helpdesk V1
+
+Once V2 is confirmed healthy and the front door proxy is routing traffic correctly, decommission the V1 Windows service.
+
+### Automated Cleanup via SSM (Preferred)
+
+```bash
+COMMAND_ID=$(aws ssm send-command \
+  --instance-ids "$MASTER_INSTANCE_ID" \
+  --document-name "AWS-RunPowerShellScript" \
+  --parameters 'commands=[
+    "Stop-Service -Name \"Duplo.ai.studio\" -Force",
+    "Get-Process | Where-Object { $_.ProcessName -like \"*Duplo.ai.studio*\" -or $_.ProcessName -like \"*AiStudio*\" } | Stop-Process -Force -ErrorAction SilentlyContinue",
+    "sc.exe delete \"Duplo.ai.studio\"",
+    "Get-Service -Name \"Duplo.ai.studio\" -ErrorAction SilentlyContinue | Select-Object Name, Status"
+  ]' \
+  --comment "Helpdesk V1 cleanup" \
+  --query "Command.CommandId" --output text)
+
+# Poll for result (check every 5s, up to 2.5 minutes)
+aws ssm get-command-invocation \
+  --command-id "$COMMAND_ID" \
+  --instance-id "$MASTER_INSTANCE_ID" \
+  --query "{Status:Status,Output:StandardOutputContent,Error:StandardErrorContent}" \
+  --output json
+```
+
+### Manual Cleanup via RDP (Fallback)
+
+If SSM is unavailable, RDP into the master VM and run the following in an **elevated PowerShell session** (Run as Administrator):
+
+```powershell
+# Stop the service
+Stop-Service -Name "Duplo.ai.studio" -Force
+
+# Kill any remaining processes
+Get-Process | Where-Object {
+  $_.ProcessName -like "*Duplo.ai.studio*" -or
+  $_.ProcessName -like "*AiStudio*"
+} | Stop-Process -Force -ErrorAction SilentlyContinue
+
+# Delete the service
+sc.exe delete "Duplo.ai.studio"
+
+# Verify the service is gone (expected: ServiceNotFound)
+Get-Service -Name "Duplo.ai.studio" -ErrorAction SilentlyContinue
+```
+
+---
+
+## Phase 5 — Update DNS
+
+After the ALB is provisioned, get the ALB DNS name and update your DNS records:
+
+```bash
+kubectl get ingress -n duploservices-helpdesk \
+  -o jsonpath='{.items[0].status.loadBalancer.ingress[0].hostname}'
+```
+
+Update your DNS provider:
+
+| Type | Name | Value |
+|---|---|---|
+| CNAME | `helpdesk.yourcompany.com` | `<alb-dns>.us-east-1.elb.amazonaws.com` |
+| CNAME | `xterm.helpdesk.yourcompany.com` | `<alb-dns>.us-east-1.elb.amazonaws.com` |
+
+If using Route 53, use an **Alias A record** instead of a CNAME.
+
+---
+
+## Rollback Plan
+
+If V2 deployment fails before V1 is decommissioned, V1 is still running and no rollback is needed — simply fix the V2 issue and retry.
+
+If V1 has already been decommissioned:
+
+1. Restore the front door proxy to point to V1 by reverting `AiStudioEndpoint`
+2. On the master VM, reinstall the V1 service from the original installer
+3. Investigate the V2 failure before retrying
+
+---
+
+## Verification Checklist
+
+After completing all phases, verify the following:
+
+- [ ] All V2 pods are Running: `kubectl get pods -n duploservices-helpdesk`
+- [ ] Portal loads at the V2 URL (e.g. `https://helpdesk.yourcompany.com`)
+- [ ] Login with Google OAuth works
+- [ ] Front door proxy is routing to V2: the DuploCloud portal's AI Studio link opens V2
+- [ ] `ENABLE_AI` flag is `true` in system settings
+- [ ] V1 `Duplo.ai.studio` service is no longer present on the master VM
+- [ ] DNS records point to the new ALB
+
+---
+
+## Troubleshooting
+
+| Issue | Resolution |
+|---|---|
+| Pods stuck in `Pending` | Check EFS CSI driver: `kubectl get pods -n kube-system \| grep efs` |
+| ALB not provisioned | Verify AWS Load Balancer Controller: `kubectl get pods -n kube-system \| grep aws-load-balancer` |
+| Front door proxy not routing to V2 | Verify `AiStudioEndpoint` was saved and the container restarted |
+| SSM cleanup fails | Fall back to RDP + manual PowerShell cleanup |
+| V1 service not found on cleanup | V1 may have already been removed in a prior attempt — proceed |
+| Portal shows 502 after front door restart | Wait 30–60 seconds for the container to fully restart |


### PR DESCRIPTION
## Summary

- **AWS Installation guide** — full standalone deployment walkthrough covering CloudFormation-based IAM access, prerequisites checklist, skill-guided and manual Helm installation, DNS setup, and post-install AWS provider configuration
- **Azure Installation guide** — Terraform-based deployment using the `azure-ai-hd-deployment-automation` repo, with Azure AI Foundry configuration (API Key + Managed Identity), App Gateway ingress, and multi-client deployment patterns
- **GCP Installation** — "Coming soon" placeholder
- **V1 → V2 Upgrade guide** — integrated mode upgrade covering tenant/ASG/EFS provisioning, front door proxy update, `ENABLE_AI` flag, V1 Windows service cleanup (SSM + RDP fallback), and rollback plan
- **Installation README** — updated with deployment scenario guidance (fresh account vs existing), CloudFormation access instructions, and links to all three provider guides
- **SUMMARY.md** — all new pages linked under the Installation section

## Test plan

- [ ] Verify all pages render correctly in GitBook preview
- [ ] Check internal links within the installation section resolve
- [ ] Confirm SUMMARY.md entries match file paths