### PR TITLE
Update AWS installation and provider guides

### DIFF
--- a/getting-started/installation/aws-installation.md
+++ b/getting-started/installation/aws-installation.md
@@ -78,7 +78,7 @@ In either of the scenarios above, we will need:&#x20;
 
 | Item                               | Required | Notes                                                                                                         |
 | ---------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------- |
-| Domain or subdomain for the portal | ✅        | e.g. `helpdesk.yourcompany.com` — does not need to be publicly accessible; a private hosted zone is supported |
+| Domain or subdomain for the portal | ✅        | e.g. `helpdesk.yourcompany.com`                                                                               |
 | xterm subdomain                    | ✅        | e.g. `xterm.helpdesk.yourcompany.com`                                                                         |
 | Access to DNS provider             | ✅        | Route 53, Cloudflare, or equivalent                                                                           |
 | Existing ACM certificate           | Optional | If not available, one will be requested during install                                                        |
@@ -111,41 +111,20 @@ Alternatively, if your organization uses IAM roles, you can create a role with `
 
 ***
 
-## Connecting AWS to DuploCloud (Post-Installation)
+## What DuploCloud Will Do
 
-Once the portal is live, you can connect AWS accounts to it so the AI agent can query and manage your infrastructure. This uses the **AWS Cloud Provider** feature inside the HelpDesk.
+Once credentials are shared, our team handles the full installation end-to-end:
 
-> Use the [CloudFormation Template](https://us-west-2.console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?templateURL=https://duploservices-ai-access-227120241369.s3.us-west-2.amazonaws.com/aws.yaml) to automatically create the IAM role needed to connect an AWS account to HelpDesk. You can also [download the template](https://duploservices-ai-access-227120241369.s3.us-west-2.amazonaws.com/aws.yaml) for review.
+* **Provision infrastructure** (if starting fresh) — create the VPC, EKS cluster, node groups, EFS filesystem, security groups, and ACM certificate
+* **Deploy HelpDesk** — install all components via Helm chart into a dedicated namespace
+* **Configure networking** — set up the ALB ingress, SSL termination, and DNS records for your portal domain
+* **Set up your environment** — configure the first providers, skills, and workspaces so your team can get started right away
+* **Verify and hand off** — confirm all services are healthy and provide the application URL
 
-The `HelpdeskAccountId` parameter in the template is the AWS account ID **where Helpdesk is deployed**. This configures the IAM trust policy so the HelpDesk service can assume the created role and manage resources in your AWS accounts.
-
-There are two authentication methods:
-
-### IAM Role (Recommended)
-
-1. Log in to the Helpdesk portal → **Providers** → select your tenant → **Cloud** tab → **+ Add**
-2. Fill in **Name**, **Type** = `AWS`, **Account ID**
-3. Go to the **Credentials** tab → **+ Add** → **Credential Type** = `IAM Role`
-4. Enter the **IAM Role ARN** to assume
-5. Add a **Scope** — select region and resource types
-6. Use the scope in a ticket to have the agent act on your AWS account
-
-### Access Key
-
-1. Follow steps 1–2 above to create a provider
-2. Go to **Credentials** → **+ Add** → **Credential Type** = `Access Key`
-3. Enter the Access Key ID and Secret Access Key
-4. Add a **Scope** and use it in tickets
-
-For full step-by-step screenshots, see the [AWS Provider guide](../integrating-providers/amazon-web-services-aws.md).
+Total time is typically **30–60 minutes**.
 
 ***
 
-## Troubleshooting
+## Connecting AWS to DuploCloud (Post-Installation)
 
-| Issue                                  | Resolution                                                                                                    |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| EFS mount targets not available        | Wait up to 10 minutes — EFS creates one mount target per subnet                                               |
-| ALB not provisioned                    | Verify AWS Load Balancer Controller is installed: `kubectl get pods -n kube-system \| grep aws-load-balancer` |
-| Pods stuck in `Pending`                | Check EFS CSI driver: `kubectl get pods -n kube-system \| grep efs`                                           |
-| ACM cert stuck in `PENDING_VALIDATION` | DNS validation CNAME records have not been added or have not propagated yet                                   |
+Once the portal is live, you can connect AWS accounts to it so the AI agent can query and manage your infrastructure. See the [AWS Provider guide](../integrating-providers/amazon-web-services-aws.md) for full setup instructions, including using the CloudFormation template to create the required IAM roles.

--- a/getting-started/integrating-providers/amazon-web-services-aws.md
+++ b/getting-started/integrating-providers/amazon-web-services-aws.md
@@ -6,6 +6,38 @@ The AWS Cloud Provider lets DuploCloud AI agents interact with your AWS account 
 
 ***
 
+## Setting Up IAM Access with CloudFormation (Recommended)
+
+Before adding credentials, you need an IAM role in your AWS account that HelpDesk can assume. The easiest way is the **DuploCloud Access CloudFormation template** — it takes 2–3 minutes and outputs Role ARNs you can use directly.
+
+> [Launch CloudFormation Stack](https://us-west-2.console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?templateURL=https://duploservices-ai-access-227120241369.s3.us-west-2.amazonaws.com/aws.yaml) | [Download Template](https://duploservices-ai-access-227120241369.s3.us-west-2.amazonaws.com/aws.yaml) | [GitHub Repo](https://github.com/duplocloud/duplocloud-helpdesk-access)
+
+**What it creates** — four IAM roles, each independently enabled or disabled:
+
+| Role | Policy | Default |
+|---|---|---|
+| `DuploCloud-AWS-Admin` | `AdministratorAccess` | Off |
+| `DuploCloud-AWS-ReadOnly` | `ReadOnlyAccess` | **On** |
+| `DuploCloud-EKS-Admin-<ClusterName>` | `AmazonEKSClusterAdminPolicy` (via EKS Access Entry) | Off |
+| `DuploCloud-EKS-ReadOnly-<ClusterName>` | `AmazonEKSViewPolicy` (via EKS Access Entry) | **On** |
+
+**Parameters:**
+
+| Parameter | Default | Description |
+|---|---|---|
+| `EnableAWSAdmin` | `false` | Creates `DuploCloud-AWS-Admin` with `AdministratorAccess` |
+| `EnableAWSReadOnly` | `true` | Creates `DuploCloud-AWS-ReadOnly` with `ReadOnlyAccess` |
+| `EnableEKSAdmin` | `false` | Creates `DuploCloud-EKS-Admin-<ClusterName>` with cluster admin access |
+| `EnableEKSReadOnly` | `true` | Creates `DuploCloud-EKS-ReadOnly-<ClusterName>` with read-only cluster access |
+| `EKSClusterName` | *(empty)* | Required if either EKS role is enabled — must match the exact cluster name |
+| `HelpdeskAccountId` | *(empty)* | The AWS account ID where HelpDesk is deployed. Sets the IAM trust policy so HelpDesk can assume the created roles. Leave empty for same-account access only. |
+
+Once the stack shows `CREATE_COMPLETE`, copy the relevant Role ARN(s) from the **Outputs** tab and use them as IAM Role credentials in the steps below.
+
+> **Revoking access:** Delete the CloudFormation stack to remove all created roles and trust policies.
+
+***
+
 ## Step 1 — Add the AWS Provider
 
 Navigate to **Providers** in the left sidebar, select your tenant (e.g. **IT**), and click the **Cloud** tab. Click **+ Add** in the top-right corner.


### PR DESCRIPTION
## Summary

- Remove troubleshooting section and domain privacy note from AWS installation guide
- Add **What DuploCloud Will Do** section covering infrastructure provisioning, HelpDesk deployment, networking setup, onboarding (providers/skills/workspaces), and handoff
- Simplify the post-install AWS connection section — brief description linking to the provider guide
- Add full **CloudFormation template reference** to the AWS provider guide with accurate parameter names, defaults, and role descriptions

## Test plan

- [ ] Verify link from aws-installation.md to the AWS provider guide resolves correctly in GitBook
- [ ] Confirm CloudFormation launch link opens correctly in AWS Console