### PR TITLE
Rewrite V1 to V2 upgrade guide

### DIFF
--- a/getting-started/installation/v1-to-v2-upgrade.md
+++ b/getting-started/installation/v1-to-v2-upgrade.md
@@ -1,54 +1,88 @@
 # Helpdesk V1 to V2 Upgrade Guide
 
-This guide covers upgrading from **Helpdesk V1** (the `Duplo.ai.studio` Windows service running on the DuploCloud master VM) to **Helpdesk V2** (a fully Kubernetes-native deployment managed via Helm, running inside a DuploCloud tenant).
+Your team is moving from the original DuploCloud AI HelpDesk to something far more powerful. HelpDesk V2 is not just an update — it's a completely new AI DevOps platform that can plan, execute, and manage complex cloud operations autonomously. This guide explains what's new, what changes for your team, and how the upgrade works.
 
 ---
 
-## What Changes
+## What is HelpDesk V2?
 
-| | V1 | V2 |
-|---|---|---|
-| **Deployment** | Windows service on the master VM | Helm chart in a Kubernetes tenant |
-| **Infrastructure** | Runs on the master host | Dedicated EKS nodes (ASG) |
-| **Storage** | Local disk on master VM | EFS (Elastic File System) |
-| **Load balancing** | Front door proxy on master VM | AWS ALB via Kubernetes Ingress |
-| **Updates** | Manual service reinstall | `helm upgrade` |
-| **Observability** | Windows Event Viewer | Kubernetes pod logs, DuploCloud portal |
+HelpDesk V2 is DuploCloud's next-generation AI platform for DevOps teams. It replaces the original AI Studio and HelpDesk with a unified system built around a richer model of how AI and engineering teams work together.
 
-V2 runs entirely within your AWS account inside a DuploCloud tenant. V2 is 100% self-hosted — all data remains in your environment.
+At its core, V2 introduces:
+
+* **Workspaces** — dedicated environments where your team and AI agents collaborate, with fine-grained access controls and separation of responsibilities
+* **Providers** — connections to any cloud or tool your team uses (AWS, Azure, GCP, GitHub, Jira, Linear, Slack, and more)
+* **Skills and Personas** — reusable AI capabilities that define how agents behave; combine them into Personas tailored to each team or role
+* **Projects** — a Spec-Driven DevOps process for large, complex work: the agent turns your requirements into a Spec, then a Plan, then executable Tasks
+* **Tickets** — the familiar conversational interface for quick, focused tasks, now backed by a far more capable agent
+
+Everything runs in your own cloud account, fully secure and entirely within your control.
 
 ---
 
 ## What's New in V2
 
-| Capability | V1 | V2 |
-|---|---|---|
-| **AI Agent** | Basic Q&A | Autonomous agent with tool execution |
-| **Web Terminal** | Not available | Browser-based terminal for agent commands |
-| **MCP Integrations** | Not available | Extensible tool integrations via MCP |
-| **Ticket Management** | Basic | Full project and ticket lifecycle management |
-| **Multi-provider support** | Single AWS account | Multiple AWS accounts, Kubernetes, Jira, Linear, Slack, and more |
-| **Updates** | Manual reinstall required | Single-command Helm chart upgrades |
+### Autonomous AI Agent
+
+V1 offered AI assistance for questions and suggestions. V2's agent acts. It reasons through multi-step problems, executes commands, adapts based on results, and works through complex tasks end-to-end — with you in control of every action.
+
+### Projects and Spec-Driven DevOps
+
+For large or complex work, V2 introduces Projects. Describe what you want to accomplish in plain language. The agent turns it into a detailed Spec, creates a phased Plan, and breaks it into Tasks that can be executed in parallel. No more managing large initiatives ticket-by-ticket.
+
+### Skills and Personas
+
+Skills are the building blocks of what your AI agent knows how to do — Kubernetes troubleshooting, Terraform provisioning, cost optimization, security scanning, and more. Personas group skills by role (SRE, DevOps, Security) so each workspace gets exactly the right capabilities.
+
+### Multi-Cloud and Multi-Tool Providers
+
+V1 was limited to your DuploCloud-managed AWS account. V2 connects to any cloud account or tool — multiple AWS accounts, Azure, GCP, GitHub repositories, Jira, Linear, Slack, and custom MCP servers — all with scoped, credential-backed access that your team controls.
+
+### Canvas and Shared Terminal
+
+Every ticket opens a Canvas — a live collaborative workspace where you see the agent's reasoning, review suggested commands, and run your own commands in a shared terminal. The agent observes your terminal activity and provides real-time guidance. You stay in control of what gets executed.
+
+### Workspaces
+
+Create multiple workspaces for different teams or functions, each with its own provider access and persona. An L1 SRE workspace might have read-only cloud access; a platform engineering workspace might have full provisioning rights. Access is scoped at the workspace level.
+
+### Reports and Artifacts
+
+V2 agents can produce reports, generate scripts and configuration files, and save artifacts directly in the ticket's secure workspace — available for review and editing before anything is applied.
+
+---
+
+## What Changes
+
+The upgrade is focused on the AI layer. Here's what stays the same and what changes for your team:
+
+**What stays the same:**
+
+* The **DuploCloud Core Automation Platform** you use today — your tenants, services, infrastructure, and configurations — remains completely unchanged
+* Any **Add-Ons** you have enabled, such as the Advanced Observability Suite or SIEM, continue to work exactly as before
+
+**What changes:**
+
+* The current **AI Suite** (AI Studio and AI HelpDesk) is replaced by **HelpDesk V2** — a significantly more capable platform
+* After the upgrade, your DuploCloud portal will include a **platform switcher** at the top of the interface, letting your team move between the Core Automation Platform and the new HelpDesk V2
 
 ---
 
 ## Upgrade Overview
 
-The upgrade is performed by DuploCloud and consists of the following steps:
+DuploCloud handles the upgrade end-to-end:
 
-1. **Deploy V2** — DuploCloud provisions a new tenant with dedicated EKS nodes and EFS storage, then deploys the V2 Helm chart. A new core platform portal version is also deployed to ensure UI compatibility with V2.
-2. **Update the portal routing** — the DuploCloud master portal's front door proxy is updated to route traffic to the new V2 endpoint.
-3. **Enable the AI feature flag** — the `ENABLE_AI` flag is enabled in the master portal system settings.
-4. **Decommission V1** — the `Duplo.ai.studio` Windows service is stopped and removed from the master VM.
-5. **Update DNS** — the portal domain is pointed to the new V2 ALB.
-
-If any issue arises before V1 is decommissioned, the process can be paused — V1 remains fully operational until V2 is confirmed healthy.
+* **Deploy HelpDesk V2** — install the new platform alongside your existing DuploCloud environment
+* **Update the portal** — add the platform switcher so your team can access both platforms from one login
+* **Set up your environment** — configure workspaces, connect your providers, and load the first set of skills and personas so your team is ready to work on day one
+* **Decommission V1** — remove the legacy AI Studio and HelpDesk once V2 is confirmed healthy
+* **Hand off** — walk your team through the new interface and make sure everything is working as expected
 
 ---
 
 ## What You Need to Provide
 
-DuploCloud already has access to your AWS account and Kubernetes cluster through the existing platform. No additional credentials are needed.
+DuploCloud already has access to your environment through the existing platform. No additional credentials are needed.
 
 Before scheduling the upgrade, confirm the following:
 
@@ -57,3 +91,16 @@ Before scheduling the upgrade, confirm the following:
 | Portal domain for V2 Helpdesk | e.g. `helpdesk.yourcompany.com` |
 | xterm subdomain | e.g. `xterm.helpdesk.yourcompany.com` |
 | Super-user email list | Comma-separated admin emails for initial access |
+
+---
+
+## You're in Good Hands
+
+The upgrade is designed to be safe and low-risk. V1 continues running in parallel throughout the process and is only decommissioned once your team has confirmed V2 is working as expected — there is no forced cutover.
+
+After go-live, DuploCloud stays with you:
+
+* **Onboarding session** — we walk your team through HelpDesk V2, the new interface, and your first workflows
+* **Ongoing support** — as your team grows into the platform, DuploCloud is available to help expand to new providers, add skills, or configure additional workspaces
+
+To schedule your upgrade, reach out to your DuploCloud account team.


### PR DESCRIPTION
## Summary

Complete rewrite of the V1 to V2 upgrade guide to be customer-facing and compelling rather than technical:

- New engaging intro positioning V2 as a major step forward
- **What is HelpDesk V2?** — new section introducing the core concepts (Workspaces, Providers, Skills, Personas, Projects)
- **What's New in V2** — rebuilt as capability-focused narrative covering autonomous agent, Spec-Driven Projects, Skills/Personas, multi-cloud providers, Canvas/Terminal, Workspaces, and Reports
- **What Changes** — reassuring section explaining the core platform stays unchanged, add-ons continue working, and a new platform switcher gives access to both
- **Upgrade Overview** — high-level bullet points (what DuploCloud does), no implementation detail
- **You're in Good Hands** — new closing section covering the staged rollout safety model, post-go-live onboarding, and ongoing support

## Test plan

- [ ] Review renders correctly in GitBook
- [ ] Confirm suitable for sharing with customers / CS team as PDF