### PR TITLE
docs: update FAQs and product updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 Temp/
 .duplocloud/
+faqs-draft.md
+ai-helpdesk-v2/product-updates-cleaned.md

--- a/ai-helpdesk-v2/product-updates.md
+++ b/ai-helpdesk-v2/product-updates.md
@@ -44,71 +44,11 @@ Changes in: `Frontend`
 
 ---
 
-**5.** `Feature` — **Core MCP Component in Helm + IRSA Support**
-The Helm chart now includes an optional DuploCloud platform MCP server component, and both agent and backend pods support IRSA role annotations.
-- New `coreMcp` component can be enabled independently with its own ingress path
-- IRSA role ARN can be set per component in values — the annotation is injected automatically
-- Fully backwards compatible — existing deployments are unaffected unless new values are set
-
-Changes in: `Helm`
-
----
-
-**6.** `Feature` — **Bedrock Model Auto-Subscription**
-A Helm-managed job now automatically accepts AWS Bedrock model access agreements during install or upgrade.
-- Runs as a post-install hook using a dedicated IAM role — no manual AWS console steps needed
-- The list of models to subscribe to is configurable in Helm values
-- Failures surface with clear diagnostic output rather than silent errors
-
-Changes in: `Helm`
-
----
-
-**7.** `Feature` — **Agent Sandbox Enhancements**
+**5.** `Feature` — **Agent Sandbox Enhancements**
 Agents can now access workspace and project directories automatically, and run Python-based MCP servers out of the box.
 - Workspace and project folders are mounted into the agent sandbox based on the platform context — no manual path configuration needed
 - Python MCP servers using the `uvx` pattern (e.g. `uvx mcp-grafana`) are now supported
 - The sandbox can be disabled via environment variable for deployments that require it
-
-Changes in: `Agent`
-
----
-
-**8.** `Enhancement` — **Backend Context & Session Reliability**
-Several improvements make agent sessions more reliable and context-aware across EKS and multi-scope environments.
-- Workspace and project identifiers are now included in the agent's operating context
-- Tickets with partially invalid scope configurations now process successfully using the valid scopes
-- EKS authentication tokens have an extended validity window for longer-running sessions
-
-Changes in: `Backend`
-
----
-
-**9.** `Enhancement` — **Service Desk UX & Entity Awareness**
-The Service Desk UI is clearer when workspace configuration has changed, and easier to navigate.
-- Scopes, personas, and skills that have been removed now show a "Removed" badge with a tooltip instead of a raw ID
-- Scope type (EKS, GitHub, etc.) is shown in the scope selection dropdown
-- The "View Ticket Details" action is now available in all ticket view modes, and the agent selector is shown consistently during bulk ticket creation
-
-Changes in: `Frontend`
-
----
-
-**10.** `Enhancement` — **Streaming Error Resilience**
-Agent streaming is more robust against errors, and usage cost reporting no longer double-counts.
-- Errors during streaming now surface as notifications in the UI rather than silently dropping the response
-- Session cost is reported once at the end of the session rather than incrementally, preventing over-reporting
-- Slack-routed messages are handled distinctly from multi-message threads for more consistent behavior
-
-Changes in: `Backend` `Agent`
-
----
-
-**11.** `Enhancement` — **Agent Max Turns Increased to 100**
-The default maximum number of agent turns per session has been raised to support longer-running tasks out of the box.
-- Default raised to 100 turns per session
-- Can be overridden per deployment via environment variable
-- Per-session cost budget cap remains configurable independently
 
 Changes in: `Agent`
 
@@ -122,7 +62,6 @@ Changes in: `Agent`
 Share AI reports with other workspaces directly from the report menu.
 - Reports can be shared with one or more workspaces via a multi-select dialog; shared reports appear in recipient workspaces with a clear indicator
 - Recipients can remove themselves without contacting the report owner
-- Backend enforces owner-only patching, tracks sharedBy/sharedAt metadata, and adds a MongoDB index for query performance
 
 Changes in: `Backend` `Frontend`
 
@@ -130,8 +69,7 @@ Changes in: `Backend` `Frontend`
 
 **2.** `Feature` — **Workspace & Project Secrets Management**
 Sensitive credentials can now be stored securely at the workspace, project, and ticket level.
-- Secrets are encrypted at rest using MongoDB Client-Side Field Level Encryption (CSFLE) with AES-256
-- Encryption master key is auto-generated in Helm; supports future migration to AWS KMS
+- Secrets are encrypted at rest using AES-256
 - UI provides dedicated modals for managing secrets across workspaces, projects, and service desk tickets
 
 Changes in: `Backend` `Frontend`
@@ -150,7 +88,6 @@ Changes in: `Backend` `Frontend`
 
 **4.** `Feature` — **Provider Credential Encryption & Custom Fields**
 Provider credentials are now encrypted at rest and support structured, typed custom field definitions.
-- Credential data migrated to an encrypted DataEx format with per-field type and sensitivity markers
 - Supports arbitrary custom key-value fields with types: string, secret, certificate, and more
 - UI provides a scrollable modal for managing structured credentials with inline editing
 
@@ -160,8 +97,7 @@ Changes in: `Backend` `Frontend`
 
 **5.** `Feature` — **Private Git Repository Skills**
 AI skills can now be loaded directly from private Git repositories.
-- Backend validates repository credentials and clones the repo into the skill directory on creation/update
-- Skills support a new PrivateGitRepo format type with configurable org, repo, branch, and folder path
+- Skills support a new Private Git Repository format type with configurable org, repo, branch, and folder path
 - Admin UI includes a Git repository configuration form within the Add/Edit skill workflow
 
 Changes in: `Backend` `Frontend`
@@ -170,9 +106,8 @@ Changes in: `Backend` `Frontend`
 
 **6.** `Feature` — **Slack Integration**
 The AI agent can now receive and respond to messages from Slack.
-- Messages from Slack are tagged with a `[slack]` prefix and processed with Slack-specific instructions
-- The agent can choose to stay silent on Slack by responding "Roger." — suppressing output cleanly
-- DoneEvent reports a `stop_reason` of `slack_silence` for silent responses
+- Messages from Slack are processed with Slack-specific instructions
+- The agent can choose to stay silent on Slack when appropriate
 
 Changes in: `Agent`
 
@@ -182,33 +117,12 @@ Changes in: `Agent`
 The AI agent can now connect to Azure AI Foundry as a backend with support for multiple Azure scopes.
 - Agents on Azure infrastructure can use Azure AI Foundry as the AI provider
 - Multiple Azure scopes supported per agent configuration
-- Controlled via the `CLAUDE_CODE_USE_FOUNDRY` environment variable
 
 Changes in: `Agent`
 
 ---
 
-**8.** `Enhancement` — **Platform Skills Refactoring**
-Platform-level skills are now seeded from the database instead of being hardcoded per project.
-- Project-specific logic removed from the agent; skills stored and managed centrally in the DB
-- Skills routed via `OriginContext.subType` for cleaner handling of dashboard and project tickets
-- UI skill-mapping form updated to reflect the new backend structure
-
-Changes in: `Backend` `Frontend` `Agent`
-
----
-
-**9.** `Enhancement` — **Real-Time Chat Connection Reliability**
-Significant improvements to SignalR connection stability and message streaming quality.
-- Connection lifecycle refactored: reconnect handlers automatically re-subscribe users to active threads
-- Streaming tokens buffered to avoid partial words mid-stream; emoji/Unicode handled correctly
-- Double-stringified JSON in streamed messages resolved; duplicate approval via emoji comparison fixed
-
-Changes in: `Frontend` `Agent`
-
----
-
-**10.** `Enhancement` — **Bulk Ticket Creation Redesign**
+**8.** `Enhancement` — **Bulk Ticket Creation Redesign**
 Creating multiple AI tickets at once is now faster and more configurable.
 - New split-pane layout separates task selection from per-task configuration (persona, skills, permissions)
 - "Apply to checked" batch mode lets you configure multiple tasks at once
@@ -218,78 +132,38 @@ Changes in: `Frontend`
 
 ---
 
-**11.** `Enhancement` — **Prompt Suggestion Auto-Submit**
+**9.** `Enhancement` — **Prompt Suggestion Auto-Submit**
 Clicking a prompt suggestion now immediately submits the request when a scope is active.
 - Suggestions auto-submit when a scope is already selected, removing an extra click
 - If no scope is selected, the scope dropdown highlights with an inline error message
-- Error clears as soon as a scope is chosen
 
 Changes in: `Frontend`
 
 ---
 
-**12.** `Enhancement` — **Persona Skills Provisioning**
+**10.** `Enhancement` — **Persona Skills Provisioning**
 Skills defined on personas are now included when provisioning agent skills.
 - Persona-level skills merged into the main skills list before provisioning
-- Duplicates deduplicated by skill `Id` to prevent double-provisioning
+- Duplicates deduplicated to prevent double-provisioning
 
 Changes in: `Agent`
 
 ---
 
-**13.** `Enhancement` — **Planning Skill as Provisioned File**
-The planning system prompt is now a versioned skill file rather than embedded code.
-- Planning and spec tickets load a `SKILL.md` from `.claude/skills/spec-plan-tasks` at runtime
-- Single-document workflow enforced: agent asks approval before moving between spec, plan, and execution
-- Tasks JSON schema strictly validated with required fields and no extra properties
-
-Changes in: `Agent`
-
----
-
-**14.** `Enhancement` — **Optional Credentials in Scope**
+**11.** `Enhancement` — **Optional Credentials in Scope**
 Credentials are no longer required for all scope types — only where they are necessary.
 - Cloud, Kubernetes, and Source Control provider types still require credentials
 - Other provider types can be scoped without credentials, reducing configuration friction
-- Validation logic updated to be type-aware
 
 Changes in: `Backend`
 
 ---
 
-**15.** `Enhancement` — **Azure AKS Credential Types**
+**12.** `Enhancement` — **Azure AKS Credential Types**
 Azure AKS clusters can now be configured with Service Principal or Managed Identity authentication.
 - Two new credential types added: Service Principal and Managed Identity
-- Field cleanup logic removes irrelevant fields when switching between credential types
 
 Changes in: `Frontend`
-
----
-
-**16.** `Bug` — **Encryption Master Key Length Fix**
-Fixed an issue where the auto-generated Helm encryption key was too short, causing decryption failures.
-- Key is now generated using `randBytes 96 | b64enc`, decoding to exactly 96 bytes as required
-- Previous alphanumeric generation only decoded to 72 bytes, causing silent encryption failures
-
-Changes in: `Helm`
-
----
-
-**17.** `Bug` — **xterm Kubeconfig Security Fix**
-Kubernetes configuration is no longer exposed in socket URL query parameters.
-- Kubeconfig now transmitted via dedicated socket events on connect and on-demand
-- Prevents kubeconfig exposure in browser network logs and server access logs
-
-Changes in: `Frontend`
-
----
-
-**18.** `Bug` — **Provider Data Migration on Empty Dataset**
-Migration no longer fails when there are no provider entries to process.
-- Returns success immediately if the provider collection is empty
-- Prevents spurious migration errors during fresh deployments
-
-Changes in: `Backend`
 
 ---
 
@@ -297,27 +171,16 @@ Changes in: `Backend`
 
 ---
 
-**1.** `Feature` — **AI Studio Merged into Main Platform**
-The AI Studio is now built into the main DuploCloud platform — no separate app needed.
-- Tickets, agents, workspaces, and personas are accessible directly from the main UI
-- Users on the platform can access AI features without switching apps
-- Merged via a single large integration PR covering all AI Studio components
-
-Changes in: `Frontend`
-
----
-
-**2.** `Feature` — **Keycloak SSO Login**
+**1.** `Enhancement` — **Keycloak SSO Login**
 Enterprises using Keycloak can now log into the AI helpdesk with their existing credentials.
 - Keycloak added as a supported identity provider alongside Microsoft SSO
 - Extra Keycloak parameters (realm, client ID, etc.) configurable via Helm
-- Joins Microsoft SSO added the previous week
 
 Changes in: `Backend`
 
 ---
 
-**3.** `Feature` — **Configurable Google Login**
+**2.** `Enhancement` — **Configurable Google Login**
 Admins can now disable Google login entirely, giving tighter control over which authentication methods are available for your deployment.
 - Google login can be turned off independently per deployment
 - Useful for enterprises that require SSO-only access policies
@@ -326,7 +189,7 @@ Changes in: `Backend`
 
 ---
 
-**4.** `Feature` — **Azure Deployment Support**
+**3.** `Feature` — **Azure Deployment Support**
 The AI helpdesk can now be deployed on Azure infrastructure, expanding support beyond AWS.
 - Azure-specific credential and configuration handling added to the backend
 - Service Principal and Managed Identity authentication supported for AKS
@@ -335,16 +198,7 @@ Changes in: `Backend`
 
 ---
 
-**5.** `Feature` — **Tickets Remember Their Persona**
-Tickets now store which persona was selected at creation, preserving AI behavior context for the full lifecycle of the conversation.
-- Persona is saved on the ticket and passed to the agent on every message
-- Enables persona-based filtering and reporting across workspaces
-
-Changes in: `Backend` `Frontend`
-
----
-
-**6.** `Feature` — **Agent Dashboard Integration**
+**4.** `Feature` — **Agent Dashboard Integration**
 Agent activity now feeds directly into dashboard metrics, giving a live view of what agents are doing across your workspaces.
 - Dashboard and agent views are more tightly integrated
 - Supports ticket and link views within dashboard panels
@@ -353,16 +207,7 @@ Changes in: `Backend` `Frontend`
 
 ---
 
-**7.** `Feature` — **Script Execution via Agent**
-The agent can now execute scripts directly as part of task processing, unlocking more complex automation workflows.
-- Supports running custom scripts beyond standard CLI commands
-- Scripts are executed in the agent's sandboxed environment
-
-Changes in: `Agent`
-
----
-
-**8.** `Feature` — **Pulumi CLI Support**
+**5.** `Enhancement` — **Pulumi CLI Support**
 The agent now has Pulumi CLI bundled, enabling infrastructure-as-code workflows using Pulumi.
 - Works alongside existing tools like `kubectl`, `aws`, and `gcloud`
 - Allows agents to manage cloud infrastructure declaratively via Pulumi
@@ -371,25 +216,7 @@ Changes in: `Agent`
 
 ---
 
-**9.** `Feature` — **Sales Prospecting Skills**
-New sales prospecting capabilities are now available to the agent, supporting GTM workflows.
-- Ties into the Apollo, Outreach, and other GTM providers added in recent weeks
-- Agent can perform outreach research and prospecting as a built-in skill
-
-Changes in: `Agent`
-
----
-
-**10.** `Feature` — **API Audit Skill**
-The agent can now perform API audits as a built-in skill — useful for reviewing API usage and identifying undocumented endpoints.
-- Helps ensure API hygiene across services
-- Available as a skill that can be assigned to tickets and agents
-
-Changes in: `Agent` `Backend`
-
----
-
-**11.** `Feature` — **Multi-Origin Ticket Support**
+**6.** `Enhancement` — **Multi-Origin Ticket Support**
 Tickets can now be created from and attributed to multiple sources — Slack, API, web UI — with origin tracked on each ticket.
 - Enables better routing, filtering, and audit trails across channels
 - Origin data available for reporting and analytics
@@ -398,7 +225,7 @@ Changes in: `Backend`
 
 ---
 
-**12.** `Feature` — **AI-Assisted Markdown Editor**
+**7.** `Feature` — **AI-Assisted Markdown Editor**
 A new standalone markdown editor with built-in AI editing support is now available within the platform.
 - Useful for drafting and refining system prompts, project descriptions, and documentation
 - AI can assist with editing and improving markdown content inline
@@ -407,7 +234,7 @@ Changes in: `Frontend`
 
 ---
 
-**13.** `Enhancement` — **Project Task as Opening Chat Message**
+**8.** `Enhancement` — **Project Task as Opening Chat Message**
 When creating a ticket from a project, the task description is now automatically posted as the first message in the conversation.
 - The agent immediately sees the full context without requiring the user to re-type it
 - Reduces friction for project-driven ticket workflows
@@ -416,7 +243,7 @@ Changes in: `Frontend`
 
 ---
 
-**14.** `Enhancement` — **Workspace Reports Enhanced**
+**9.** `Enhancement` — **Workspace Reports Enhanced**
 Workspace reports now include project files and ticket names, giving a more complete view of all activity and output within a workspace.
 - Project files included in report generation
 - Ticket names surfaced for better report organization
@@ -425,40 +252,11 @@ Changes in: `Backend`
 
 ---
 
-**15.** `Enhancement` — **Cost Optimization: Smarter Agent Planning**
+**10.** `Enhancement` — **Cost Optimization: Smarter Agent Planning**
 The agent's planning and spec-writing prompts now only activate for ticket types that actually require them, reducing unnecessary token usage.
 - Cuts cost on routine tasks without affecting quality on complex ones
-- Planning prompts scoped to `plan_creation` and `spec_creation` ticket types only
 
 Changes in: `Agent`
-
----
-
-**16.** `Enhancement` — **Helm / Infrastructure**
-Terminal (xterm) enabled by default, persistent sessions, and zero-downtime rolling updates added to the Helm chart.
-- xterm enabled by default — no manual config needed to get terminal access
-- Flask secret key added so terminal sessions survive pod restarts
-- Zero-downtime rolling updates configured for xterm and Slack backend deployments
-
-Changes in: `Helm`
-
----
-
-**17.** `Bug` — **Credential Cleanup After Each Session**
-Cloud credentials are now automatically wiped from temporary storage after every agent session.
-- Closes a potential window where credentials could linger on disk between task runs
-- Applies to all cloud credential types (AWS, GCP, Azure)
-
-Changes in: `Agent`
-
----
-
-**18.** `Bug` — **Security Improvements**
-Several security issues identified in an internal review have been addressed.
-- Fixes to permission set group caching and data access controls
-- Prevents unauthorized access to cross-workspace data
-
-Changes in: `Backend`
 
 ---
 
@@ -494,7 +292,7 @@ Changes in: `Backend`
 
 ---
 
-**4.** `Feature` — **Multiple Personas per Workspace**
+**4.** `Enhancement` — **Multiple Personas per Workspace**
 Workspaces now support multiple personas, giving more flexibility in how the AI behaves across different use cases within the same workspace.
 - When creating a ticket, you can choose which persona to use for that conversation
 - System prompt field removed from ticket creation — persona handles this instead
@@ -515,7 +313,6 @@ Changes in: `Frontend`
 **6.** `Feature` — **GRC (Governance, Risk & Compliance) Provider Tab**
 A new GRC provider category tab is now available in the admin providers panel, joining the existing IT and GTM categories.
 - Allows GRC tool integrations to be organized separately from IT/GTM providers
-- Consistent with the multi-category provider navigation pattern
 
 Changes in: `Frontend`
 
@@ -557,76 +354,12 @@ Changes in: `Backend`
 
 ---
 
-**11.** `Feature` — **v1.0.0 Release**
-The AI Helpdesk backend has been bumped to v1.0.0, marking the first major stable release.
-- Signals production readiness of the core platform
-- Versioning now follows semantic versioning
-
-Changes in: `Backend`
-
----
-
-**12.** `Enhancement` — **HTML Artifact Viewer Improvements**
+**11.** `Enhancement` — **HTML Artifact Viewer Improvements**
 HTML artifacts can now be viewed in fullscreen mode, and external links show a confirmation before navigating away.
 - Dedicated expand button opens artifacts in a fullscreen overlay
 - Prevents accidental navigation away from the current session
 
 Changes in: `Frontend`
-
----
-
-**13.** `Enhancement` — **API Token Enhancements**
-Building on last week's long-lived token feature — tokens can now be searched and linked to group users.
-- Tokens searchable by name or value for easier management
-- Tokens can be linked to group users for shared access scenarios
-
-Changes in: `Backend` `Frontend`
-
----
-
-**14.** `Enhancement` — **Clearer Validation Error Messages**
-When a request references entities that don't exist, you now get clear error messages listing exactly which entities are missing.
-- Replaces generic failure messages with actionable details
-- Applies across workspace, project, and ticket validation
-
-Changes in: `Backend`
-
----
-
-**15.** `Enhancement` — **Real-Time Ticket Processing Status**
-The ticket status is now updated immediately when processing begins, so the UI reflects that the agent is working as soon as a message is sent.
-- No longer waits for the first agent response to show "processing" status
-- Improves perceived responsiveness for users waiting on long tasks
-
-Changes in: `Backend`
-
----
-
-**16.** `Enhancement` — **Streaming Reliability Improvements**
-Under-the-hood improvements to how streaming messages are buffered and synchronized, reducing out-of-order or missing chunks.
-- Buffering logic improved for long agent responses
-- Reduces visible glitches in streamed output
-
-Changes in: `Agent` `Frontend`
-
----
-
-**17.** `Enhancement` — **Generic Scope Type Support**
-The agent can now handle custom or non-standard scope/provider types generically, rather than failing on unrecognized types.
-- New integrations can be used even before explicit agent support is added
-- Reduces the need for code changes when onboarding new provider types
-
-Changes in: `Agent`
-
----
-
-**18.** `Enhancement` — **Helm / Infrastructure**
-Auto-scaling, graceful shutdown, and routing improvements added to the Helm chart.
-- HPA (Horizontal Pod Autoscaler) and graceful shutdown added for the duploAgent
-- DuploMasterUrl added to ingress routing for better compatibility with DuploCloud portal deployments
-- Fixed backend startup issue caused by missing `INFRA_REGION` environment variable
-
-Changes in: `Helm`
 
 ---
 
@@ -638,7 +371,6 @@ Changes in: `Helm`
 AI responses now stream to your screen as they are generated, rather than waiting for the full response to complete.
 - Fixed intermittent cases where streaming would stall or produce malformed output
 - Collaborative messages from other users in the same session now also appear in real-time
-- Fixed connection timing issues that could cause messages to be missed on load
 
 Changes in: `Backend` `Frontend`
 
@@ -664,7 +396,7 @@ Changes in: `Backend` `Frontend`
 
 ---
 
-**4.** `Feature` — **Ticket Name Prefixes**
+**4.** `Enhancement` — **Ticket Name Prefixes**
 Workspaces now support a short name field used as a prefix when generating ticket names, making tickets easier to identify across workspaces.
 - Short names must be unique within a workspace and start with a letter
 - Editable on both create and edit workspace forms
@@ -675,8 +407,6 @@ Changes in: `Backend` `Frontend`
 
 **5.** `Feature` — **Ticket Summaries**
 Tickets now automatically generate a compacted summary of the conversation, giving you a quick overview without scrolling through the full history.
-- Summary logic runs as a service layer operation, not a hook
-- Accessible via a dedicated API endpoint
 
 Changes in: `Backend`
 
@@ -691,27 +421,16 @@ Changes in: `Backend` `Frontend`
 
 ---
 
-**7.** `Feature` — **Sales & Marketing (GTM) Provider Support**
-A new Sales & Marketing provider category is now available alongside the existing IT providers.
-- Sales: Apollo, Outreach, Zoom, Attention, Gong; Marketing: HubSpot
-- Organized in a dedicated GTM tab in the admin providers panel, separate from IT providers
-- Provider navigation menu restructured into collapsible IT and GTM sub-sections
-
-Changes in: `Backend` `Frontend`
-
----
-
-**8.** `Feature` — **User Identity in Chat Messages**
+**7.** `Enhancement` — **User Identity in Chat Messages**
 Chat messages now show who sent them — display name (with fallback to email) and a color avatar.
 - Makes it easier to follow conversations with multiple participants
 - Mentions in activity chat now show user avatars and display names in the dropdown
-- Current user is automatically excluded from the mention list
 
 Changes in: `Backend` `Frontend`
 
 ---
 
-**9.** `Feature` — **Unread Message Badge**
+**8.** `Enhancement` — **Unread Message Badge**
 The activity sidebar now displays an unread message count badge so you can see new messages arriving without keeping the chat panel open.
 - Badge updates in real-time as new messages arrive
 - Clears when the chat panel is opened
@@ -720,77 +439,18 @@ Changes in: `Frontend`
 
 ---
 
-**10.** `Feature` — **Observability & Security Dashboards**
-New dashboard views for Observability and Security metrics are now available in the admin panel, backed by a new metrics and policy data model.
-- Separated and refactored metric model classes for extensibility
-- Model objects for Dashboard entities added to the backend
+**9.** `Feature` — **Observability & Security Dashboards**
+New dashboard views for Observability and Security metrics are now available in the admin panel.
 
 Changes in: `Backend` `Frontend`
 
 ---
 
-**11.** `Enhancement` — **Command Output in Chat**
+**10.** `Enhancement` — **Command Output in Chat**
 Long command outputs in chat are now collapsed by default for a cleaner view, with a clear expand control to see the full output when needed.
 - Expandable/collapsible with hover tooltips
-- Auto-scroll behavior improved so the terminal doesn't hijack your scroll position
 
 Changes in: `Frontend`
-
----
-
-**12.** `Enhancement` — **Command Execution Permissions Redesign**
-The UI for configuring which commands an agent can run automatically has been redesigned with clearer toggle cards, replacing the previous layout.
-- Labels are now "auto-approval" and "auto-rejection" for better clarity
-- Replaces the previous ambiguous layout
-
-Changes in: `Frontend`
-
----
-
-**13.** `Enhancement` — **Ticket List Improvements**
-The ticket list now shows a Created By column and a Copy Ticket Name quick action.
-- Created By column shows who opened each ticket at a glance
-- Copy Ticket Name available from the ticket actions dropdown
-- Long ticket titles now show a tooltip on hover instead of truncating silently
-
-Changes in: `Frontend`
-
----
-
-**14.** `Enhancement` — **Helm / Infrastructure**
-Helm chart updated with MongoDB backups, configurable Claude model version, and DuploCloud MCP server bundled by default.
-- MongoDB backups now configured in Helm for data durability
-- Claude model version is now configurable via an environment variable
-- DuploCloud MCP server enabled by default; shared output volume added for cross-ticket processing
-
-Changes in: `Helm`
-
----
-
-**15.** `Bug` — **Secure Credential Injection in Terminal**
-AWS, GCP, and Kubernetes credentials are now injected securely into terminal sessions behind the scenes — no longer visible as `export` commands in terminal output.
-- Credentials sent via Socket.IO events instead of shell export commands
-- Reduces credential exposure risk in terminal output and URL parameters
-
-Changes in: `Frontend`
-
----
-
-**16.** `Bug` — **Agent Session Stability**
-Fixed an issue where long-running agent sessions would silently drop their connection mid-task.
-- Sessions can now stay active for up to 30 minutes without timing out
-- Improved agent instructions for more consistent file handling behavior
-
-Changes in: `Agent`
-
----
-
-**17.** `Bug` — **Security Fix: Blocked Path Traversal**
-Fixed a security vulnerability where specially crafted document requests could access files outside the intended directory scope.
-- Path traversal attempts are now blocked at the agent level
-- No user action required
-
-Changes in: `Agent`
 
 ---
 
@@ -905,12 +565,12 @@ Secure AI assistance for security-conscious organizations:
 
 ### Key Benefits
 
-**🤖 Intelligent Automation** - AI Agents that understand your infrastructure and can take action with your approval
+**Intelligent Automation** - AI Agents that understand your infrastructure and can take action with your approval
 
-**🛡️ Security First** - Human oversight for all actions with your credentials, never autonomous access
+**Security First** - Human oversight for all actions with your credentials, never autonomous access
 
-**🚀 Faster Resolution** - Collaborative workspace where you and AI work together to solve problems
+**Faster Resolution** - Collaborative workspace where you and AI work together to solve problems
 
-**📊 Better Insights** - Automatic diagram generation and intelligent analysis of your systems
+**Better Insights** - Automatic diagram generation and intelligent analysis of your systems
 
-**🔒 Enterprise Ready** - Private AI models with complete data privacy and security controls
+**Enterprise Ready** - Private AI models with complete data privacy and security controls

--- a/faqs.md
+++ b/faqs.md
@@ -14,18 +14,11 @@ description: >-
 
 DuploCloud runs within your own cloud account. The platform itself is a small footprint — a few Docker containers, a MongoDB instance, and a few S3 buckets.
 
-DuploCloud organizes cloud infrastructure into three nested layers:
+The product has three main layers:
 
-Infrastructure
-The top-level construct. Each Infrastructure maps to a unique VPC in a cloud region and optionally includes a Kubernetes (EKS/GKE/AKS) or ECS cluster. When you create one, DuploCloud automatically provisions the underlying networking — VPC, public/private subnets per availability zone, NAT Gateway, Internet Gateway, route tables, and security groups. Most organizations create two: one for production, one for non-production.
-
-Plan
-Automatically created alongside each Infrastructure (with the same name). A Plan acts as a configuration template shared across all Tenants inside it — defining things like load balancer certificates, VM images, WAF rules, IAM policies, DNS domains, and resource quotas. Any setting in the Plan applies uniformly to every Tenant beneath it.
-
-Tenant
-The project-level workspace within an Infrastructure. All cloud resources (services, databases, storage, etc.) live inside a Tenant. Tenants provide isolation via security groups, IAM roles, Kubernetes namespaces, and KMS keys. Resources within the same Tenant communicate freely; cross-Tenant traffic requires explicit configuration. Tenants also drive billing, alerting, and access control — admins can grant developers access to specific Tenants only.
-
-In short: Infrastructure = network/region, Plan = shared config template, Tenant = project workspace.
+1. **Workspace** — the organizational unit where all DevOps work is orchestrated. Each Workspace bundles together Scopes (access to your infrastructure) and Personas (sets of Skills that define how the agent behaves). You can create multiple Workspaces and invite users to specific ones, giving different teams precisely the access and capabilities they need.
+2. **AI DevOps Platform** — the work surface for task-level and project-level objectives. Accessible via web browser, Slack, Teams, or directly in an IDE, this is where tickets are created and assigned to the agent. For simple one-off tasks, create a Ticket directly. For large, complex work, use Projects — which break the work into a Spec, Plan, and Tasks that the agent executes with your oversight.
+3. **Integrations** — the connectivity layer that links the agent to your actual infrastructure through cloud providers (AWS, GCP, Azure), Kubernetes clusters (EKS, AKS, GKE), Git repositories (GitHub, GitLab, Bitbucket), observability tools, and MCP servers. Access is granted through Providers and Scopes, with temporary just-in-time credentials passed to the agent at execution time.
 
 Your existing infrastructure — Terraform state, Kubernetes clusters, CI/CD pipelines — is not migrated or replaced. The agent connects to it through the integrations layer using the permissions you define.
 
@@ -89,7 +82,7 @@ The main differences: DuploCloud gives you access to the full breadth of cloud-n
 
 <summary>How long does it take to get started?</summary>
 
-The platform is designed to be operational quickly. Setup involves deploying a few Docker containers, connecting your cloud and Git providers, and configuring the Helpdesk Platform with the appropriate Skills and Scopes. All of which can be done in a few minutes, not days.
+The platform is designed to be operational quickly. Setup involves deploying a few Docker containers, connecting your cloud and Git providers, and configuring the AI DevOps Platform with the appropriate Skills and Scopes. All of which can be done in a few minutes, not days.
 
 The 30-day PoC is structured to deliver measurable results against real infrastructure within the first sprint. Please contact the team to start scoping your onboarding.
 
@@ -99,7 +92,7 @@ The 30-day PoC is structured to deliver measurable results against real infrastr
 
 <summary>What does DuploCloud set up for us during onboarding?</summary>
 
-DuploCloud's team handles the initial platform setup as part of onboarding. This includes deploying the platform to your cloud environment, connecting your cloud and Git providers, and configuring your Skills, Scopes, and MCP server integrations for your ticketing and observability tools.
+DuploCloud's team handles the initial platform setup as part of onboarding. This includes deploying the platform to your cloud environment, connecting your cloud and Git providers, and configuring your Workspaces, Skills, Scopes, and MCP server integrations for your ticketing and observability tools.
 
 The overall onboarding flow follows the same structure as before — dev deployment, evaluation, QA, production cutover — but the project plan is now managed inside the product rather than a spreadsheet, so your team can track and collaborate on it in real time.
 
@@ -202,7 +195,7 @@ See [Providers](introduction/ai-devops-policy-model/providers.md) for the full l
 
 <summary>Do you support self-hosted or on-premise deployments?</summary>
 
-DuploCloud runs within your own cloud environment — your infrastructure, your accounts, your data. The platform uses AWS Bedrock to ensure sensitive data never leaves your AWS environment.
+DuploCloud runs within your own cloud environment — your infrastructure, your accounts, your data. The platform ensures sensitive data never leaves your cloud environment.
 
 For customers with strict data residency or on-premise requirements, contact [support@duplocloud.net](mailto:support@duplocloud.net) to discuss deployment options.
 
@@ -553,7 +546,7 @@ Each Scope defines the exact resources the DevOps agent can access. Guardrails c
 
 <summary>What is the audit trail for AI actions?</summary>
 
-Every ticket maintains a full context and audit trail throughout its lifecycle — what the agent was asked to do, what it proposed, what was approved, and what was executed. The Engineer Hub surfaces this history for each DevOps agent, providing a transparent record of all completed work. Completed task history is also stored in the platform's Knowledge Base, queryable for future reference.
+Every ticket maintains a full context and audit trail throughout its lifecycle — what the agent was asked to do, what it proposed, what was approved, and what was executed. Completed task history is stored in the platform's Knowledge Base, queryable for future reference.
 
 </details>
 
@@ -563,7 +556,7 @@ Every ticket maintains a full context and audit trail throughout its lifecycle �
 
 There are two complementary layers:
 
-**DuploCloud ticket history** — every ticket maintains a complete record of what the agent was asked to do, what commands it proposed, what was approved, and what was executed, including the full diff for any changes. This is accessible in the Engineer Hub for each DevOps agent and searchable from the Knowledge Base.
+**DuploCloud ticket history** — every ticket maintains a complete record of what the agent was asked to do, what commands it proposed, what was approved, and what was executed, including the full diff for any changes. This history is searchable from the Knowledge Base.
 
 **Cloud-native audit trails** — all agent actions are executed through standard cloud and infrastructure interfaces, and appear in your existing audit infrastructure. Your cloud provider's audit logging records every API call the agent makes, including the identity it used and the timestamp. These records live in your account, independent of DuploCloud.
 

--- a/faqs.md
+++ b/faqs.md
@@ -14,13 +14,20 @@ description: >-
 
 DuploCloud runs within your own cloud account. The platform itself is a small footprint — a few Docker containers, a MongoDB instance, and a few S3 buckets.
 
-The product has three main layers:
+DuploCloud organizes cloud infrastructure into three nested layers:
 
-1. **Engineer Hub** — where you create and manage your AI DevOps Engineers (Platform Engineers, CI/CD Engineers, SRE Engineers, and more). You define high-level project requirements here; the Engineer converts them into a detailed plan and coordinates a team of agents to execute it.
-2. **Agentic AI Helpdesk** — the work surface for task-level objectives. Accessible via web browser, Slack, Teams, or directly in an IDE, this is where tickets are created, assigned to specialized agents, and completed. Agents include SRE, Kubernetes, cloud-specific, Docs, and Architecture agents.
-3. **Integrations** — the connectivity layer that links agents to your actual infrastructure through cloud providers (AWS, GCP, Azure), Kubernetes clusters (EKS, AKS, GKE), Git repositories (GitHub, GitLab, Bitbucket), observability tools, and MCP servers. Access is granted through Providers and Scopes, with temporary just-in-time credentials passed to agents at execution time.
+Infrastructure
+The top-level construct. Each Infrastructure maps to a unique VPC in a cloud region and optionally includes a Kubernetes (EKS/GKE/AKS) or ECS cluster. When you create one, DuploCloud automatically provisions the underlying networking — VPC, public/private subnets per availability zone, NAT Gateway, Internet Gateway, route tables, and security groups. Most organizations create two: one for production, one for non-production.
 
-Your existing infrastructure — Terraform state, Kubernetes clusters, CI/CD pipelines — is not migrated or replaced. Agents connect to it through the integrations layer using the permissions you define.
+Plan
+Automatically created alongside each Infrastructure (with the same name). A Plan acts as a configuration template shared across all Tenants inside it — defining things like load balancer certificates, VM images, WAF rules, IAM policies, DNS domains, and resource quotas. Any setting in the Plan applies uniformly to every Tenant beneath it.
+
+Tenant
+The project-level workspace within an Infrastructure. All cloud resources (services, databases, storage, etc.) live inside a Tenant. Tenants provide isolation via security groups, IAM roles, Kubernetes namespaces, and KMS keys. Resources within the same Tenant communicate freely; cross-Tenant traffic requires explicit configuration. Tenants also drive billing, alerting, and access control — admins can grant developers access to specific Tenants only.
+
+In short: Infrastructure = network/region, Plan = shared config template, Tenant = project workspace.
+
+Your existing infrastructure — Terraform state, Kubernetes clusters, CI/CD pipelines — is not migrated or replaced. The agent connects to it through the integrations layer using the permissions you define.
 
 </details>
 
@@ -28,13 +35,13 @@ Your existing infrastructure — Terraform state, Kubernetes clusters, CI/CD pip
 
 <summary>What makes DuploCloud different from using Claude Code or similar AI coding tools?</summary>
 
-DuploCloud is a multi-agent platform, not a single-user coding assistant. The key differences:
+DuploCloud is an AI DevOps platform, not a single-user coding assistant. The key differences:
 
 **1. Shared system of intelligence — context doesn't live on individual laptops** With Claude Code or Cursor, every session starts from scratch. Work done by one engineer isn't visible to teammates, investigations can't be handed off mid-task, and the same context has to be re-established every time. DuploCloud centralises this: every ticket, investigation, and outcome is stored in a shared knowledge base. The second time a similar task runs — a migration, a compliance check, a cluster upgrade — the agent already knows your environment and asks significantly fewer questions.
 
-**2. Team collaboration and handoff** A task started by one engineer can be continued by another without losing context. Projects, tickets, and plans are visible across the team in a shared workspace, and agents can work in parallel across team members' tasks simultaneously.
+**2. Team collaboration and handoff** A task started by one engineer can be continued by another without losing context. Projects, tickets, and plans are visible across the team in a shared workspace, and the agent can work on team members' tasks simultaneously.
 
-**3. Scale and security — credentials managed centrally, not tied to individual laptops** DuploCloud manages credentials at the platform level, generating scoped, temporary access per ticket. Because the platform runs in your cloud rather than on a developer's laptop, it isn't constrained by local machine availability, access, or session limits. Agents are also restricted to the specific repositories and cloud accounts defined in the Scope for that task — they cannot reach outside their boundaries to gather context, which is a common failure mode with local AI tools.
+**3. Scale and security — credentials managed centrally, not tied to individual laptops** DuploCloud manages credentials at the platform level, generating scoped, temporary access per ticket. Because the platform runs in your cloud rather than on a developer's laptop, it isn't constrained by local machine availability, access, or session limits. The agent is also restricted to the specific repositories and cloud accounts defined in the Scope for that task — it cannot reach outside its boundaries to gather context, which is a common failure mode with local AI tools.
 
 **4. Always-on, not session-bound** A long-running task continues after hours, results are surfaced when complete, and the system keeps working while the team is offline.
 
@@ -46,7 +53,7 @@ If your team already uses Claude Code or Cursor for local development, DuploClou
 
 <summary>We already have DevOps engineers. Why would we use DuploCloud?</summary>
 
-The same reason companies with thousands of software engineers still give every developer Claude Code or Cursor: AI tools act as a force multiplier, not a replacement. Your engineers direct the work; DuploCloud's AI handles the repetitive and time-consuming parts — routine infrastructure tickets, compliance evidence collection, PR reviews, EKS optimisation passes, cost analysis — so your team can focus on higher-leverage work.
+The same reason companies with thousands of software engineers still give every developer Claude Code or Cursor: AI tools act as a force multiplier, not a replacement. Your engineers direct the work; DuploCloud's AI DevOps Agent handles the repetitive and time-consuming parts — routine infrastructure tickets, compliance evidence collection, PR reviews, EKS optimisation passes, cost analysis — so your team can focus on higher-leverage work.
 
 For teams with lean or overloaded DevOps functions, this means eliminating the intake ticket backlog and reducing context-switching. For larger teams, it means running complex projects in parallel rather than sequentially, and removing single points of failure when engineers are unavailable.
 
@@ -58,7 +65,7 @@ DuploCloud also handles work that falls between the cracks of typical DevOps too
 
 <summary>We don't have a dedicated DevOps engineer. Is DuploCloud a viable alternative to hiring one?</summary>
 
-For many teams, yes. A dedicated DevOps engineer typically costs $150–200K or more per year in salary; DuploCloud starts at a fraction of that. Beyond cost, the platform works continuously — tickets can run after hours, agents can monitor your environment around the clock, and there's no on-call rotation.
+For many teams, yes. A dedicated DevOps engineer typically costs $150–200K or more per year in salary; DuploCloud starts at a fraction of that. Beyond cost, the platform works continuously — tickets can run after hours, the agent can monitor your environment around the clock, and there's no on-call rotation.
 
 The clearest fit is teams where routine deployments, compliance evidence collection, cost optimisation, and incident triage consume significant engineering time that your existing team has to absorb.
 
@@ -74,7 +81,7 @@ If you're at the stage of considering your first DevOps hire, a 30-day PoC scope
 
 Yes — the ease of use is comparable. Teams often start on Heroku for its simplicity and move to AWS for production scale; DuploCloud is designed to give you Heroku-like simplicity on top of AWS (and GCP and Azure), without the cost and limitations of Heroku at scale.
 
-The main differences: DuploCloud gives you access to the full breadth of cloud-native services that Heroku abstracts away, and DuploCloud plus your cloud provider is generally significantly more cost-effective at higher traffic volumes. The added flexibility does introduce some complexity, but DuploCloud's support and AI agents are there to absorb that complexity rather than pass it to your team.
+The main differences: DuploCloud gives you access to the full breadth of cloud-native services that Heroku abstracts away, and DuploCloud plus your cloud provider is generally significantly more cost-effective at higher traffic volumes. The added flexibility does introduce some complexity, but DuploCloud's support and AI agent are there to absorb that complexity rather than pass it to your team.
 
 </details>
 
@@ -82,7 +89,7 @@ The main differences: DuploCloud gives you access to the full breadth of cloud-n
 
 <summary>How long does it take to get started?</summary>
 
-The platform is designed to be operational quickly. Setup involves deploying a few Docker containers, connecting your cloud and Git providers, and configuring an Engineer with the appropriate Skills and Scopes. All of which can be done in a few minutes, not days.
+The platform is designed to be operational quickly. Setup involves deploying a few Docker containers, connecting your cloud and Git providers, and configuring the Helpdesk Platform with the appropriate Skills and Scopes. All of which can be done in a few minutes, not days.
 
 The 30-day PoC is structured to deliver measurable results against real infrastructure within the first sprint. Please contact the team to start scoping your onboarding.
 
@@ -92,11 +99,11 @@ The 30-day PoC is structured to deliver measurable results against real infrastr
 
 <summary>What does DuploCloud set up for us during onboarding?</summary>
 
-DuploCloud's team handles the initial platform setup as part of onboarding. This includes deploying the platform to your cloud environment, connecting your cloud and Git providers, and configuring your first Engineers with personas, Skills, Scopes, and MCP server integrations for your ticketing and observability tools.
+DuploCloud's team handles the initial platform setup as part of onboarding. This includes deploying the platform to your cloud environment, connecting your cloud and Git providers, and configuring your Skills, Scopes, and MCP server integrations for your ticketing and observability tools.
 
 The overall onboarding flow follows the same structure as before — dev deployment, evaluation, QA, production cutover — but the project plan is now managed inside the product rather than a spreadsheet, so your team can track and collaborate on it in real time.
 
-The team will also configure Skills to reflect your code conventions and operational standards before handoff, so agents are working to your patterns from day one.
+The team will also configure Skills to reflect your code conventions and operational standards before handoff, so the agent is working to your patterns from day one.
 
 </details>
 
@@ -110,7 +117,7 @@ In practice:
 
 * **Application ownership** — your team owns Docker containers, application code, and anything inside them.
 * **Infrastructure ownership** — DuploCloud manages cloud infrastructure, Kubernetes configuration, CI/CD pipeline setup, compliance controls, and operational runbooks.
-* **Decision authority** — your team retains final approval on every infrastructure change before it is executed. Engineers direct the work; agents and DuploCloud's operations team execute it.
+* **Decision authority** — your team retains final approval on every infrastructure change before it is executed. Engineers direct the work; the agent and DuploCloud's operations team execute it.
 
 The platform is self-service once onboarded — your engineers can initiate and approve tickets directly — but the standard expectation during onboarding is that DuploCloud's team drives the work while your team reviews and approves.
 
@@ -118,13 +125,13 @@ The platform is self-service once onboarded — your engineers can initiate and 
 
 <details>
 
-<summary>Who performs the day-to-day DevOps work — AI agents, DuploCloud engineers, or our team?</summary>
+<summary>Who performs the day-to-day DevOps work — the AI agent, DuploCloud engineers , or our team?</summary>
 
 All three, depending on the work and service model:
 
-**AI agents** handle execution — running commands, generating infrastructure plans, analysing logs, producing diffs, and surfacing results for approval. Every action requires human sign-off before it is applied.
+**The AI agent** handles execution — running commands, generating infrastructure plans, analysing logs, producing diffs, and surfacing results for approval. Every action requires human sign-off before it is applied.
 
-**DuploCloud's engineers** configure and maintain the agents, and handle work that requires human judgment — complex incidents, sensitive infrastructure changes, and anything outside the agents' defined Scope. Under the fully managed model, DuploCloud's team is accountable for outcomes, not just tooling.
+**DuploCloud's engineers** configure and maintain the agent, and handle work that requires human judgment — complex incidents, sensitive infrastructure changes, and anything outside the agent's defined Scope. Under the fully managed model, DuploCloud's team is accountable for outcomes, not just tooling.
 
 **Your engineers** direct priorities, review and approve proposed changes, and own the application layer. Once onboarded, the platform is designed to be self-service — your team can run tickets directly without going through DuploCloud.
 
@@ -195,7 +202,7 @@ See [Providers](introduction/ai-devops-policy-model/providers.md) for the full l
 
 <summary>Do you support self-hosted or on-premise deployments?</summary>
 
-DuploCloud runs within your own cloud environment — your infrastructure, your accounts, your data. The PrivateGPT Agent, for example, uses AWS Bedrock to ensure sensitive data never leaves your AWS environment.
+DuploCloud runs within your own cloud environment — your infrastructure, your accounts, your data. The platform uses AWS Bedrock to ensure sensitive data never leaves your AWS environment.
 
 For customers with strict data residency or on-premise requirements, contact [support@duplocloud.net](mailto:support@duplocloud.net) to discuss deployment options.
 
@@ -221,7 +228,7 @@ For teams who want automated update management, the platform can be configured t
 
 It depends on the agent. For AWS and Kubernetes, the platform primarily uses the CLI — LLMs have strong CLI comprehension and it provides precise, auditable execution. For third-party systems that publish MCP servers (observability tools, ticketing systems, etc.), DuploCloud uses those MCP endpoints directly.
 
-Agents are flexible. DuploCloud's core value is in the overall orchestration layer — individual agents can be modified or replaced for your specific environment. See [MCP Servers](introduction/ai-devops-policy-model/mcp-servers.md) for configuration details.
+The agent is flexible. DuploCloud's core value is in the overall orchestration layer — the agent can be modified or replaced for your specific environment. See [MCP Servers](introduction/ai-devops-policy-model/mcp-servers.md) for configuration details.
 
 </details>
 
@@ -240,22 +247,22 @@ Long-running tasks like generating code reviews or large deployments use the pub
 
 <details>
 
-<summary>Is agent memory persistent, and can it be shared across agents?</summary>
+<summary>Is agent memory persistent?</summary>
 
-Agents themselves are stateless — each execution starts fresh with the context provided in the ticket. Persistence lives at the help desk layer: every ticket maintains a full history of the investigation, actions taken, and outcomes. This history is stored in the Engineer's Knowledge Base and is accessible to any agent working on related tickets.
+The agent is stateless — each execution starts fresh with the context provided in the ticket. Persistence lives at the help desk layer: every ticket maintains a full history of the investigation, actions taken, and outcomes. This history is stored in the platform's Knowledge Base and is accessible to the agent when working on related tickets.
 
-The result is shared, searchable memory at the system level without individual agents needing to carry state between runs. Agents working on a follow-up ticket can query prior work, and human team members can review or build on the full investigation history.
+The result is shared, searchable memory at the system level without the agent needing to carry state between runs. The agent working on a follow-up ticket can query prior work, and human team members can review or build on the full investigation history.
 
 </details>
 
 <details>
 
-<summary>How do you give AI agents context?</summary>
+<summary>How do you give the AI agent context?</summary>
 
 Context is assembled from four layers and delivered to the agent as part of each ticket:
 
-1. **Graph database** — DuploCloud maintains a graph of your infrastructure that captures relationships between hosts, services, pods, dependencies, and cloud resources — giving agents a structured, queryable map of your environment rather than just flat text.
-2. **Knowledge Base retrieval** — the platform uses vector search over the Engineer's Knowledge Base (previous tickets, runbooks, architecture notes) to pull relevant prior work into the prompt.
+1. **Graph database** — DuploCloud maintains a graph of your infrastructure that captures relationships between hosts, services, pods, dependencies, and cloud resources — giving the agent a structured, queryable map of your environment rather than just flat text.
+2. **Knowledge Base retrieval** — the platform uses vector search over the platform's Knowledge Base (previous tickets, runbooks, architecture notes) to pull relevant prior work into the prompt.
 3. **Skills** — best practices, guardrails, and operational patterns are encoded as Skills and included in the agent's system prompt. This is how domain expertise is consistently applied without relying on the model to infer it.
 4. **Scope credentials** — the agent receives temporary, just-in-time credentials scoped to the exact resources it's permitted to access, so it has the access it needs without ever needing to ask for it.
 
@@ -281,7 +288,7 @@ For one-off Help Desk tickets, the agent works with the context it has and follo
 
 <summary>Does DuploCloud's AI actually execute tasks, or does it just give recommendations?</summary>
 
-It executes. When assigned a ticket, DuploCloud's agents run real commands against your infrastructure — `kubectl` operations, AWS CLI calls, Terraform plans and applies — and surface the results for your review before any changes are committed.
+It executes. When assigned a ticket, DuploCloud's agent runs real commands against your infrastructure — `kubectl` operations, AWS CLI calls, Terraform plans and applies — and surfaces the results for your review before any changes are committed.
 
 The workflow is: the agent takes action, produces a diff or output, and presents it with an explanation. You approve or reject before anything is applied. For example, an EKS cost optimisation ticket might result in the agent analysing 12 nodes, identifying memory and CPU inefficiencies across workloads, and proposing specific resource adjustments — all executable in one click after your review.
 
@@ -301,53 +308,19 @@ Specialized personas also make it easier to enforce security boundaries. An agen
 
 <details>
 
-<summary>Can we build custom agents or bring our own?</summary>
+<summary>Can the AI agent assist with compliance evidence collection and audit preparation?</summary>
 
-Yes. There are three options:
-
-1. **Prebuilt Agents** — use DuploCloud's out-of-the-box agents as-is.
-2. **Dynamic Agents** — build agents through the platform UI by defining a prompt, selecting tools, choosing an LLM, and deploying a container image.
-3. **Bring your own** — connect an existing agent by providing its access endpoint. DuploCloud can also provide code for its own agents as a starting point.
-
-See [Agents](ai-suite/ai-studio/agents.md) for setup instructions.
-
-</details>
-
-<details>
-
-<summary>What agents come out of the box?</summary>
-
-DuploCloud provides the following pre-built agents:
-
-| Agent                      | What it does                                                                   |
-| -------------------------- | ------------------------------------------------------------------------------ |
-| SRE Agent                  | Orchestrates specialist sub-agents for broad incident and operations support   |
-| Kubernetes Agent           | Cluster management, health checks, resource management, log analysis           |
-| Observability Agent        | Monitoring and performance via OpenTelemetry and Grafana                       |
-| CI/CD Agent                | Pipeline troubleshooting for Jenkins and GitHub Actions                        |
-| Architecture Diagram Agent | Generates infrastructure diagrams from AWS and Kubernetes resources            |
-| PrivateGPT Agent           | Secure, enterprise ChatGPT-like experience running within your AWS environment |
-| Database Explorer Agent    | Safe database queries via pre-approved templates                               |
-
-See the [full list of out-of-the-box agents](https://docs.duplocloud.com/docs/ai-suite/ai-helpdesk/out-of-the-box-agents).
-
-</details>
-
-<details>
-
-<summary>Can AI agents assist with compliance evidence collection and audit preparation?</summary>
-
-Yes — this is one of the platform's core use cases. Agents can run scheduled compliance checks across your cloud environments and produce structured evidence artifacts automatically.
+Yes — this is one of the platform's core use cases. The agent can run scheduled compliance checks across your cloud environments and produce structured evidence artifacts automatically.
 
 Specific capabilities include:
 
 * Cross-account scans against compliance controls (SOC 2, HITRUST, ISO 27001)
-* Continuous drift detection: agents flag resources that fall out of compliance between audit cycles, rather than discovering gaps at audit time
+* Continuous drift detection: the agent flags resources that fall out of compliance between audit cycles, rather than discovering gaps at audit time
 * Evidence packaging for auditor review, drawn from ticket history, logs, and live environment state
-* GRC platform integration: agents keep controls green in platforms like Drata and Vanta by flagging issues as they arise
+* GRC platform integration: the agent keeps controls green in platforms like Drata and Vanta by flagging issues as they arise
 * Persistent runbooks and control attestation in the knowledge base, making each subsequent audit cycle faster
 
-Agents operate with read-only scope by default. Remediation actions require explicit human approval before execution — the platform notifies; it does not auto-remediate.
+The agent operates with read-only scope by default. Remediation actions require explicit human approval before execution — the platform notifies; it does not auto-remediate.
 
 For teams who want DuploCloud to take accountability for compliance outcomes — evidence collection, ongoing control monitoring, and auditor liaison — this is available as a managed service.
 
@@ -355,25 +328,25 @@ For teams who want DuploCloud to take accountability for compliance outcomes —
 
 <details>
 
-<summary>Are the prebuilt agents and skills built only by DuploCloud, or can others contribute?</summary>
+<summary>Are the prebuilt agent and skills built only by DuploCloud, or can others contribute?</summary>
 
-Prebuilt agents and skills are developed and maintained by DuploCloud, in close collaboration with customers and partners. They are not community-sourced in the open-source sense — this means every skill ships with a quality bar and has been validated against real workloads.
+The prebuilt agent and skills are developed and maintained by DuploCloud, in close collaboration with customers and partners. They are not community-sourced in the open-source sense — this means every skill ships with a quality bar and has been validated against real workloads.
 
-That said, the platform is fully extensible. You can build your own skills, modify existing ones, or use skills published by third-party vendors. For example, Hashicorp publishes a Terraform skill that you can plug directly into your agents.
+That said, the platform is fully extensible. You can build your own skills, modify existing ones, or use skills published by third-party vendors. For example, Hashicorp publishes a Terraform skill that you can plug directly into the agent.
 
 </details>
 
 <details>
 
-<summary>How much work is it to set up and maintain agents and skills?</summary>
+<summary>How much work is it to set up and maintain the agent and skills?</summary>
 
-Initial setup is handled by DuploCloud's team as part of onboarding — Engineers, personas, Skills, and Scopes are configured against your environment before you run your first task.
+Initial setup is handled by DuploCloud's team as part of onboarding — the DevOps agent, personas, Skills, and Scopes are configured against your environment before you run your first task.
 
 Ongoing maintenance depends on which service model you choose:
 
-* **Fully managed** — DuploCloud's operations team owns the agents, keeps Skills updated, and is accountable for task outcomes. You direct the work (priorities, what to tackle next); the team handles the rest.
+* **Fully managed** — DuploCloud's operations team owns the agent, keeps Skills updated, and is accountable for task outcomes. You direct the work (priorities, what to tackle next); the team handles the rest.
 * **Hybrid** — your team runs day-to-day tasks, with DuploCloud available for complex or sensitive work.
-* **Self-serve** — your team owns configuration and upkeep. Prebuilt agents and Skills are maintained by DuploCloud and require no ongoing effort from you, but custom agents you build yourself are your responsibility.
+* **Self-serve** — your team owns configuration and upkeep. The prebuilt agent and Skills are maintained by DuploCloud and require no ongoing effort from you, but custom agent Skills you configure yourself are your responsibility.
 
 Skills encode their logic as explicit, versioned instructions — not trained weights. Updating a Skill means editing text, not retraining a model. Prebuilt Skills don't accumulate drift over time.
 
@@ -383,7 +356,7 @@ Skills encode their logic as explicit, versioned instructions — not trained we
 
 <summary>Can we automate our existing runbooks and release processes?</summary>
 
-Yes — this is a direct use case. Documented processes (release checklists, hotfix procedures, incident runbooks) can be converted into Skills, which agents execute step-by-step with the same guardrails applied to any other task: scoped credentials, human approval before execution, and a full audit trail.
+Yes — this is a direct use case. Documented processes (release checklists, hotfix procedures, incident runbooks) can be converted into Skills, which the agent executes step-by-step with the same guardrails applied to any other task: scoped credentials, human approval before execution, and a full audit trail.
 
 The conversion is straightforward: your runbook becomes a structured Skill that the agent follows. On a release trigger, the agent works through the steps, surfaces any exceptions or decisions that require human input, and completes the process. Engineers stay in the loop without needing to run every command themselves.
 
@@ -405,7 +378,7 @@ The DuploCloud DevOps agent uses LLMs from Anthropic.  Haiku, Sonnet, or Opus ca
 
 DuploCloud works with managed LLM services from major cloud providers — AWS Bedrock, GCP Vertex AI, and Azure AI Foundry, for example — depending on your cloud environment. Using managed services means your data stays within your own cloud account and is not used to train third-party models. This is important for enterprise security and compliance requirements.
 
-The platform is model-agnostic at the agent level. DuploCloud's team continuously evaluates new models as they are released and updates default model assignments based on what performs best for each task type — reasoning-heavy tasks like Terraform plan analysis may use a different model than higher-volume tasks like log summarisation. Customers can always override the default and choose specific models for specific agents.
+The platform is model-agnostic at the agent level. DuploCloud's team continuously evaluates new models as they are released and updates default model assignments based on what performs best for each task type — reasoning-heavy tasks like Terraform plan analysis may use a different model than higher-volume tasks like log summarisation. Customers can always override the default and choose specific models for the agent.
 
 </details>
 
@@ -427,7 +400,7 @@ If you're choosing between platforms and AI-assisted operations is a priority, D
 
 <summary>Can you show us some Jenkins agents?</summary>
 
-Yes — DuploCloud has deployed Jenkins agents for multiple customers. The out-of-the-box [CI/CD Agent](https://docs.duplocloud.com/docs/ai-suite/ai-helpdesk/out-of-the-box-agents) supports Jenkins and GitHub Actions pipeline troubleshooting. Please contact the team to arrange a targeted demonstration.
+Yes — DuploCloud has deployed Jenkins agents for multiple customers. The DuploCloud DevOps agent supports Jenkins and GitHub Actions pipeline troubleshooting. Please contact the team to arrange a targeted demonstration.
 
 </details>
 
@@ -435,7 +408,7 @@ Yes — DuploCloud has deployed Jenkins agents for multiple customers. The out-o
 
 <summary>Can we use our existing Terraform, Helm, or other IaC?</summary>
 
-Yes. The platform includes a Terraform Skill out of the box, covering plan, apply, state management, and error handling. Helm and Kubernetes deployments are handled by the Kubernetes Agent and Skills. External Skill packages from HashiCorp and Pulumi can also be made available to the agents. Your existing IaC files, modules, and conventions are used as-is — the agent works with your code, not a replacement for it.
+Yes. The platform includes a Terraform Skill out of the box, covering plan, apply, state management, and error handling. Helm and Kubernetes deployments are handled by the DevOps agent and Skills. External Skill packages from HashiCorp and Pulumi can also be made available to the agent. Your existing IaC files, modules, and conventions are used as-is — the agent works with your code, not a replacement for it.
 
 </details>
 
@@ -445,10 +418,10 @@ Yes. The platform includes a Terraform Skill out of the box, covering plan, appl
 
 Yes. Two mechanisms ensure this:
 
-1. **Repository access** — agents with access to your infrastructure repository read your existing code before generating anything new. They infer your naming conventions, module structure, and organisational patterns and apply them to new output rather than falling back on generic defaults.
+1. **Repository access** — the agent with access to your infrastructure repository reads your existing code before generating anything new. It infers your naming conventions, module structure, and organisational patterns and applies them to new output rather than falling back on generic defaults.
 2. **Skills** — you can explicitly encode your standards as a Skill (module naming conventions, required tags, resource organisation patterns). Skills are included in the agent's system prompt and applied consistently to every task regardless of who initiates it.
 
-For Terraform specifically, agents generate code within your existing directory structure and variable conventions. If the agent is uncertain about a convention, it surfaces the decision in the spec or plan phase for you to confirm before generating any code.
+For Terraform specifically, the agent generates code within your existing directory structure and variable conventions. If the agent is uncertain about a convention, it surfaces the decision in the spec or plan phase for you to confirm before generating any code.
 
 Code review is part of the standard workflow. The platform presents the diff in the ticket interface alongside the agent's reasoning before any changes are applied — you're never committed to output you haven't reviewed.
 
@@ -473,9 +446,9 @@ For teams using GitOps (Flux, ArgoCD), PR mode integrates naturally — the agen
 
 <summary>Does DuploCloud support GitOps workflows (Flux, ArgoCD)?</summary>
 
-Yes. Custom agents and Skills can be built for GitOps tools like Flux and ArgoCD. The platform's core model — agents operating on your Git repositories with scoped access and a full audit trail of proposed changes — maps naturally to GitOps pull-based delivery.
+Yes. The agent can be configured with custom Skills for GitOps tools like Flux and ArgoCD. The platform's core model — the agent operating on your Git repositories with scoped access and a full audit trail of proposed changes — maps naturally to GitOps pull-based delivery.
 
-A GitOps-focused agent can manage Flux Kustomizations, HelmReleases, and GitRepository resources alongside your existing reconciliation workflow. Contact the team to scope a custom agent for your GitOps environment.
+The agent, configured for GitOps, can manage Flux Kustomizations, HelmReleases, and GitRepository resources alongside your existing reconciliation workflow. Contact the team to scope a GitOps configuration for your environment.
 
 </details>
 
@@ -486,7 +459,7 @@ A GitOps-focused agent can manage Flux Kustomizations, HelmReleases, and GitRepo
 Terraform variable management is addressed at three levels:
 
 1. **System of record** — variables and configuration are backed by your Git repositories. The platform treats your existing repo structure as the source of truth and works within it rather than replacing it.
-2. **Scope-based access control** — each environment (dev, staging, production) is modeled as a separate Scope with its own credentials and boundaries. Engineers only access the variables relevant to the Scope they're operating in, preventing cross-environment leakage.
+2. **Scope-based access control** — each environment (dev, staging, production) is modeled as a separate Scope with its own credentials and boundaries. The DevOps agent only accesses the variables relevant to the Scope it's operating in, preventing cross-environment leakage.
 3. **Skills** — Terraform Skills encode best practices for module structure, variable organization, and environment promotion patterns, ensuring consistency across environments regardless of which team member or agent is making changes.
 
 If you're partway through a migration, the platform can scan your existing repositories and cloud accounts to identify gaps and generate a remediation plan.
@@ -497,7 +470,7 @@ If you're partway through a migration, the platform can scan your existing repos
 
 <summary>How does DuploCloud integrate with our existing CI/CD pipeline?</summary>
 
-Git repositories (GitHub, GitLab, Bitbucket) are modeled as [Providers](introduction/ai-devops-policy-model/providers.md) with scoped access. The out-of-the-box [CI/CD Agent](https://docs.duplocloud.com/docs/ai-suite/ai-helpdesk/out-of-the-box-agents) integrates with Jenkins and GitHub Actions for pipeline troubleshooting and automation. For deeper pipeline integration, custom agents or Skills can be configured to fit your specific workflow.
+Git repositories (GitHub, GitLab, Bitbucket) are modeled as [Providers](introduction/ai-devops-policy-model/providers.md) with scoped access. The DuploCloud DevOps agent integrates with Jenkins and GitHub Actions for pipeline troubleshooting and automation. For deeper pipeline integration, custom Skills can be configured to fit your specific workflow.
 
 </details>
 
@@ -507,7 +480,7 @@ Git repositories (GitHub, GitLab, Bitbucket) are modeled as [Providers](introduc
 
 Yes. The platform connects to project management and documentation tools through the Provider and MCP server model.
 
-Jira and GitHub are supported as out-of-the-box integrations — agents can create, update, and link Jira tickets to DuploCloud tasks, and open pull requests on your repositories directly from a ticket. Documentation tools like Notion can be connected via MCP servers to provide agents with access to your specs and design documents during the planning phase.
+Jira and GitHub are supported as out-of-the-box integrations — the agent can create, update, and link Jira tickets to DuploCloud tasks, and open pull requests on your repositories directly from a ticket. Documentation tools like Notion can be connected via MCP servers to provide the agent with access to your specs and design documents during the planning phase.
 
 A common workflow: a spec lives in Notion, the agent reads it during the project planning phase, generates a detailed task breakdown, and creates corresponding Jira tickets. As tasks are completed, the Jira tickets update to reflect progress. The full project history is retained in DuploCloud, while your existing project tracking system remains the system of record.
 
@@ -519,7 +492,7 @@ A common workflow: a spec lives in Notion, the agent reads it during the project
 
 No — they're complementary. GRC platforms like Drata, Vanta, and Thoropass identify compliance gaps and manage the audit workflow. DuploCloud does the technical work to close those gaps: building controls into your infrastructure, remediating findings, and keeping them green as your environment evolves.
 
-A common pattern: your GRC platform flags a control as failing; DuploCloud's agents identify the root cause, propose a remediation, and execute it after your approval. DuploCloud integrates directly with GRC platforms to keep control statuses current.
+A common pattern: your GRC platform flags a control as failing; DuploCloud's agent identifies the root cause, proposes a remediation, and executes it after your approval. DuploCloud integrates directly with GRC platforms to keep control statuses current.
 
 </details>
 
@@ -555,7 +528,7 @@ Users are added to the prod portal but their access is strictly scoped within Du
 
 <summary>How do you give access to Git?</summary>
 
-Git is modeled as a Provider — the same way AWS, Kubernetes, and observability tools are. To give an Engineer Git access:
+Git is modeled as a Provider — the same way AWS, Kubernetes, and observability tools are. To give the DevOps agent Git access:
 
 1. Navigate to **Providers** and add your Git provider (GitHub, GitLab, or Bitbucket).
 2. Add your repository credentials under the **Credentials** tab.
@@ -570,9 +543,9 @@ See [Providers](introduction/ai-devops-policy-model/providers.md) for step-by-st
 
 <summary>How are credentials stored and secured?</summary>
 
-Credentials are stored in DuploCloud or referenced from your own secrets manager. The platform uses them to generate scoped, temporary access at execution time — credentials are never passed to agents directly or stored in session context.
+Credentials are stored in DuploCloud or referenced from your own secrets manager. The platform uses them to generate scoped, temporary access at execution time — credentials are never passed to the agent directly or stored in session context.
 
-Each Scope defines the exact resources an Engineer can access. Guardrails can further restrict specific resources, operations, or environments within that Scope. See [AI DevOps Policy Model](introduction/ai-devops-policy-model/) — Provider and Scope.
+Each Scope defines the exact resources the DevOps agent can access. Guardrails can further restrict specific resources, operations, or environments within that Scope. See [AI DevOps Policy Model](introduction/ai-devops-policy-model/) — Provider and Scope.
 
 </details>
 
@@ -580,7 +553,7 @@ Each Scope defines the exact resources an Engineer can access. Guardrails can fu
 
 <summary>What is the audit trail for AI actions?</summary>
 
-Every ticket maintains a full context and audit trail throughout its lifecycle — what the agent was asked to do, what it proposed, what was approved, and what was executed. The Engineer Hub surfaces this history per Engineer, providing a transparent record of all completed work. Completed task history is also stored in the Engineer's Knowledge Base, queryable for future reference.
+Every ticket maintains a full context and audit trail throughout its lifecycle — what the agent was asked to do, what it proposed, what was approved, and what was executed. The Engineer Hub surfaces this history for each DevOps agent, providing a transparent record of all completed work. Completed task history is also stored in the platform's Knowledge Base, queryable for future reference.
 
 </details>
 
@@ -590,7 +563,7 @@ Every ticket maintains a full context and audit trail throughout its lifecycle �
 
 There are two complementary layers:
 
-**DuploCloud ticket history** — every ticket maintains a complete record of what the agent was asked to do, what commands it proposed, what was approved, and what was executed, including the full diff for any changes. This is accessible in the Engineer Hub per Engineer and searchable from the Knowledge Base.
+**DuploCloud ticket history** — every ticket maintains a complete record of what the agent was asked to do, what commands it proposed, what was approved, and what was executed, including the full diff for any changes. This is accessible in the Engineer Hub for each DevOps agent and searchable from the Knowledge Base.
 
 **Cloud-native audit trails** — all agent actions are executed through standard cloud and infrastructure interfaces, and appear in your existing audit infrastructure. Your cloud provider's audit logging records every API call the agent makes, including the identity it used and the timestamp. These records live in your account, independent of DuploCloud.
 
@@ -600,7 +573,7 @@ If an incident needs investigation, you can trace through both layers: the Duplo
 
 <details>
 
-<summary>How do you protect our environment from your AI agents?</summary>
+<summary>How do you protect our environment from the AI agent?</summary>
 
 Protection is enforced at the infrastructure level, not just the policy level — meaning the constraints are structural and cannot be bypassed by the agent regardless of what it's asked to do.
 
@@ -608,7 +581,7 @@ Three layers apply:
 
 1. **Scoped credentials** — the agent receives temporary, just-in-time credentials generated from the Scope you assign to the ticket. Those credentials carry only the permissions you defined. If the Scope doesn't include permission to modify a particular resource or environment, the agent cannot do it — not because it's been instructed not to, but because the credentials don't allow it.
 2. **Skills as guardrails** — operational guardrails (safety checks, approval steps, resource boundaries) are encoded as Skills and applied to every task. Skills are explicit, versioned instructions evaluated before execution — not model-dependent inference that could vary between runs.
-3. **Human approval before every execution** — agents propose changes and wait for explicit human approval before applying anything. No action is taken autonomously on production infrastructure.
+3. **Human approval before every execution** — the agent proposes changes and waits for explicit human approval before applying anything. No action is taken autonomously on production infrastructure.
 
 The posture is: make bad outcomes structurally impossible first, then add Skills and approval flows as additional layers on top.
 
@@ -618,7 +591,7 @@ The posture is: make bad outcomes structurally impossible first, then add Skills
 
 <summary>What if a user accidentally pastes credentials or secrets into a prompt?</summary>
 
-DuploCloud applies a security validation Skill to all agents. When an agent detects that a prompt contains patterns consistent with secrets — API keys, access tokens, passwords, or cloud provider credentials — it refuses to process the request and returns a warning explaining why.
+DuploCloud applies a security validation Skill to the agent. When the agent detects that a prompt contains patterns consistent with secrets — API keys, access tokens, passwords, or cloud provider credentials — it refuses to process the request and returns a warning explaining why.
 
 More broadly, the platform is designed so that users never need to supply credentials in prompts at all. Credentials are managed at the Scope level and injected as temporary, just-in-time credentials at execution time. If a user tries to bypass this by pasting credentials directly, the security Skill acts as a catch.
 
@@ -638,7 +611,7 @@ DuploCloud is SOC 2 certified. Full security documentation is available for proc
 
 <summary>Does DuploCloud provide SOC 2 certification or conduct security audits?</summary>
 
-No — DuploCloud is not an auditor and does not issue certifications. What DuploCloud does is ensure your infrastructure meets SOC 2, HIPAA, HITRUST, PCI, and other framework requirements on an ongoing basis: compliance controls are built directly into every deployment, agents continuously scan for drift, and evidence is collected and packaged automatically for auditor review.
+No — DuploCloud is not an auditor and does not issue certifications. What DuploCloud does is ensure your infrastructure meets SOC 2, HIPAA, HITRUST, PCI, and other framework requirements on an ongoing basis: compliance controls are built directly into every deployment, the agent continuously scans for drift, and evidence is collected and packaged automatically for auditor review.
 
 When you're ready for formal attestation, you engage a qualified auditor directly (or through your GRC platform). DuploCloud can connect you with auditors and provides the infrastructure evidence and control documentation they need.
 
@@ -650,7 +623,7 @@ Penetration testing is available as a DuploCloud service offering, which is typi
 
 <summary>Does the AI agent collect data in any capacity?</summary>
 
-No. Agents only access metrics and logs from within your own cloud account, and only with your approval before any action is taken. No data leaves your account, and no data collection occurs beyond what is needed to respond to your request.
+No. The agent only accesses metrics and logs from within your own cloud account, and only with your approval before any action is taken. No data leaves your account, and no data collection occurs beyond what is needed to respond to your request.
 
 </details>
 
@@ -662,8 +635,8 @@ No. Agents only access metrics and logs from within your own cloud account, and 
 
 There are two layers of protection:
 
-1. **Deterministic, permission-based controls** — the Scope you assign to an Engineer defines exactly what IAM permissions the agent gets. The platform uses those permissions to generate temporary credentials passed to the agent as part of the ticket. The agent cannot act outside those boundaries regardless of what it's asked to do.
-2. **Skills** — best practices and operational guardrails are encoded directly into the agent's Skills. Skills define not just what an agent can do, but how it should do it, including safety checks and approval steps.
+1. **Deterministic, permission-based controls** — the Scope you assign to the DevOps agent defines exactly what IAM permissions it gets. The platform uses those permissions to generate temporary credentials passed to the agent as part of the ticket. The agent cannot act outside those boundaries regardless of what it's asked to do.
+2. **Skills** — best practices and operational guardrails are encoded directly into the agent's Skills. Skills define not just what the agent can do, but how it should do it, including safety checks and approval steps.
 
 DuploCloud's human operations team also acts as a reliability layer — reviewing complex work and stepping in when something requires human judgment.
 
@@ -671,9 +644,9 @@ DuploCloud's human operations team also acts as a reliability layer — reviewin
 
 <details>
 
-<summary>What happens when an AI agent encounters an error during execution?</summary>
+<summary>What happens when the AI agent encounters an error during execution?</summary>
 
-The default behaviour when an agent hits an error is to stop, surface the error with an explanation, and wait for human review — not to attempt self-remediation or find an alternative path to completion.
+The default behaviour when the agent hits an error is to stop, surface the error with an explanation, and wait for human review — not to attempt self-remediation or find an alternative path to completion.
 
 The agent presents:
 
@@ -685,7 +658,7 @@ For multi-step tasks (a Kubernetes upgrade, an infrastructure apply across envir
 
 If the agent identifies that it lacks the prerequisites to complete a task — a missing dependency, insufficient permissions, a resource not in the expected state — it surfaces this during the plan phase before any execution begins. The intent is to fail fast and verbosely, not to proceed into a half-complete state.
 
-Agents don't take autonomous "best-effort" alternative paths. If you approved a specific plan and an error occurs, the agent stops at the point of failure and reports back. Any retry or alternative approach requires your explicit instruction.
+The agent doesn't take autonomous "best-effort" alternative paths. If you approved a specific plan and an error occurs, the agent stops at the point of failure and reports back. Any retry or alternative approach requires your explicit instruction.
 
 </details>
 
@@ -699,7 +672,7 @@ Every ticket maintains a complete record of what the agent was asked to do, ever
 
 Beyond passive visibility:
 
-* Agents explain their reasoning, or can be prompted to provide reasoning, in plain language before each approval step, so your team learns from the work as it happens rather than receiving a black-box result.
+* The agent explains its reasoning, or can be prompted to provide reasoning, in plain language before each approval step, so your team learns from the work as it happens rather than receiving a black-box result.
 * The Ticket History stores every investigation as a record — your team can review how a problem was previously solved or why a particular approach was taken.
 * Skills encode operational standards as readable text instructions, not trained model weights — your team can inspect exactly what guardrails govern the agent's behaviour.
 
@@ -709,27 +682,27 @@ Your engineers remain in the approval loop for every proposed change. The platfo
 
 <details>
 
-<summary>Can AI agents be trusted to make compliance decisions, or does human judgment still have a role?</summary>
+<summary>Can the AI agent be trusted to make compliance decisions, or does human judgment still have a role?</summary>
 
-For technically deterministic compliance work — scanning environments for misconfigurations, collecting evidence against a control, verifying that a resource meets a specific policy — agents perform reliably and can run autonomously within their defined Scope.
+For technically deterministic compliance work — scanning environments for misconfigurations, collecting evidence against a control, verifying that a resource meets a specific policy — the agent performs reliably and can run autonomously within its defined Scope.
 
-For judgment-heavy decisions — interpreting ambiguous regulatory requirements, determining whether a specific implementation satisfies a regulator's intent, or navigating evolving frameworks like the EU AI Act or global data privacy laws — human expertise remains essential. The platform is built around this distinction: agents propose findings and actions, humans review and approve before anything is executed. DuploCloud's human operations team is available throughout for guidance on implementation decisions, not just execution.
+For judgment-heavy decisions — interpreting ambiguous regulatory requirements, determining whether a specific implementation satisfies a regulator's intent, or navigating evolving frameworks like the EU AI Act or global data privacy laws — human expertise remains essential. The platform is built around this distinction: the agent proposes findings and actions, humans review and approve before anything is executed. DuploCloud's human operations team is available throughout for guidance on implementation decisions, not just execution.
 
 Three layers apply to every agent action:
 
-1. **Scoped access** — agents receive only the IAM permissions defined in the ticket's Scope and cannot act outside those boundaries.
+1. **Scoped access** — the agent receives only the IAM permissions defined in the ticket's Scope and cannot act outside those boundaries.
 2. **Skills** — compliance patterns and guardrails are encoded as Skills and applied consistently, independent of model inference.
 3. **Human approvals** — changes to infrastructure or configuration require explicit sign-off before execution.
 
-The practical model: agents automate evidence collection, continuous monitoring, and remediation recommendations; humans review what those findings mean and decide what to do about them.
+The practical model: the agent automates evidence collection, continuous monitoring, and remediation recommendations; humans review what those findings mean and decide what to do about them.
 
 </details>
 
 <details>
 
-<summary>How do LLM model updates work, and will they affect my agents?</summary>
+<summary>How do LLM model updates work, and will they affect the agent?</summary>
 
-DuploCloud is model-agnostic. Each agent is configured to use a specific model through your cloud provider's managed LLM service (e.g., AWS Bedrock, Azure OpenAI), which you control. Model updates are not applied automatically — you decide when to change the model an agent uses.
+DuploCloud is model-agnostic. Each agent is configured to use a specific model through your cloud provider's managed LLM service (e.g., AWS Bedrock, Azure OpenAI), which you control. Model updates are not applied automatically — you decide when to change the model the agent uses.
 
 DuploCloud monitors model performance across its customer base and makes recommendations when a newer model produces meaningfully better results for a specific task type (e.g., Kubernetes operations, Terraform plan analysis). These are recommendations, not forced updates.
 
@@ -761,7 +734,7 @@ The Knowledge Base and ticket history are stored in your own repositories and ca
 
 <summary>How does DuploCloud help with cloud cost visibility and unexpected cost increases?</summary>
 
-DuploCloud agents can audit your cloud environment for common cost drivers — unused or oversized resources, missing VPC endpoints generating data egress charges, untagged infrastructure with no cost attribution, and instances left running after workloads moved to managed services.
+The DuploCloud agent can audit your cloud environment for common cost drivers — unused or oversized resources, missing VPC endpoints generating data egress charges, untagged infrastructure with no cost attribution, and instances left running after workloads moved to managed services.
 
 Cost savings are attributed to specific tickets in the audit trail, giving you a clear record of what was changed and why.
 
@@ -781,11 +754,11 @@ There is no token-based billing. DuploCloud charges based on **tickets** (tasks 
 
 <summary>Does using DuploCloud's AI result in additional LLM costs on top of the platform fee?</summary>
 
-Yes, but they are typically small and predictable. When agents run, they invoke LLMs through managed cloud services — AWS Bedrock, GCP Vertex AI, or Azure AI Foundry — that run within your own cloud account. Those token costs appear as standard cloud charges in your bill at the provider's listed rates. DuploCloud does not add a markup.
+Yes, but they are typically small and predictable. When the agent runs, it invokes LLMs through managed cloud services — AWS Bedrock, GCP Vertex AI, or Azure AI Foundry — that run within your own cloud account. Those token costs appear as standard cloud charges in your bill at the provider's listed rates. DuploCloud does not add a markup.
 
 DuploCloud's own billing model does not charge per token — you pay per ticket and per node under management, not per API call. This means your platform costs don't scale unpredictably with usage volume.
 
-For most workloads, the LLM charges per ticket are low relative to the engineering time saved. For teams with cost sensitivity, agents can be configured to start with minimal Skills and add them incrementally — a lower-token baseline for initial evaluation that can be extended as the platform proves value.
+For most workloads, the LLM charges per ticket are low relative to the engineering time saved. For teams with cost sensitivity, the agent can be configured to start with minimal Skills and add them incrementally — a lower-token baseline for initial evaluation that can be extended as the platform proves value.
 
 </details>
 
@@ -793,7 +766,7 @@ For most workloads, the LLM charges per ticket are low relative to the engineeri
 
 <summary>What exactly counts as a "ticket"?</summary>
 
-A ticket is a unit of work assigned to an AI agent. In the workflow, a human approves a Task generated from a Project Plan — at that point, the Task becomes a Ticket and is dispatched to the appropriate agent for execution. Each ticket corresponds to one discrete, agent-executed action or investigation. See [AI Helpdesk - Tickets](ai-suite/ai-helpdesk/tickets.md) for details.
+A ticket is a unit of work assigned to the AI agent. In the workflow, a human approves a Task generated from a Project Plan — at that point, the Task becomes a Ticket and is dispatched to the agent for execution. Each ticket corresponds to one discrete, agent-executed action or investigation. See [AI Helpdesk - Tickets](ai-suite/ai-helpdesk/tickets.md) for details.
 
 </details>
 
@@ -809,7 +782,7 @@ Nodes under management refers to the infrastructure resources — servers, Kuber
 
 <summary>What's included in the 30-day PoC?</summary>
 
-The PoC gives you a working AI Engineer running against your real infrastructure. DuploCloud's human operations team — infrastructure engineers, Kubernetes specialists, and security practitioners — is included to support setup, review complex work, and ensure the PoC runs against tasks from your actual backlog. Contact the team to scope a PoC around your specific environment.
+The PoC gives you a working DevOps agent running against your real infrastructure. DuploCloud's human operations team — infrastructure engineers, Kubernetes specialists, and security practitioners — is included to support setup, review complex work, and ensure the PoC runs against tasks from your actual backlog. Contact the team to scope a PoC around your specific environment.
 
 </details>
 
@@ -817,9 +790,9 @@ The PoC gives you a working AI Engineer running against your real infrastructure
 
 <summary>Does DuploCloud track ROI metrics — tickets resolved, PRs generated, time saved?</summary>
 
-Activity is tracked at the ticket level — every completed task records what was done, what commands were executed, what changes were proposed and approved, and how long it took. This data is queryable via the Analytics Agent: you ask in natural language and it queries project history directly, answering questions like "how many tickets were completed this sprint," "what was the infrastructure cost delta over this project," or "how does AI-assisted throughput compare to estimated manual effort."
+Activity is tracked at the ticket level — every completed task records what was done, what commands were executed, what changes were proposed and approved, and how long it took. This data is queryable via the agent: you ask in natural language and it queries project history directly, answering questions like "how many tickets were completed this sprint," "what was the infrastructure cost delta over this project," or "how does AI-assisted throughput compare to estimated manual effort."
 
-An analytics dashboard is on the roadmap. Agent-level observability is already built in: all agents emit OpenTelemetry traces and metrics (latency, failure rates, success rates) to your cloud's monitoring stack (e.g., AWS X-Ray), enabling benchmarking of individual agent performance over time.
+An analytics dashboard is on the roadmap. Agent-level observability is already built in: the agent emits OpenTelemetry traces and metrics (latency, failure rates, success rates) to your cloud's monitoring stack (e.g., AWS X-Ray), enabling benchmarking of agent performance over time.
 
 For PoC engagements, the team can structure the evaluation around specific KPIs — establishing a baseline before the PoC starts and measuring against it at the end. A common methodology is comparing the token cost and human oversight time for a given project done with distributed local AI tools against the same project run centrally through DuploCloud.
 


### PR DESCRIPTION
## Summary
- Updated FAQs to reflect single-agent model: removed references to multiple specialized agents, replaced product-concept "Engineer" with "DevOps agent" or "platform", removed two obsolete FAQ blocks (custom agents, out-of-the-box agents list)
- Cleaned up product updates: removed bug fixes, internal details, Helm items, and specific removed items; renumbered remaining entries
- Added draft working files (`faqs-draft.md`, `product-updates-cleaned.md`) to `.gitignore`

## Test plan
- [ ] Review FAQs for consistent single-agent language throughout
- [ ] Verify product updates sections are correctly numbered
- [ ] Confirm draft files do not appear in the PR diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)